### PR TITLE
Drop Fallback Support For Supported Types

### DIFF
--- a/src/installers.ts
+++ b/src/installers.ts
@@ -67,10 +67,6 @@ const MOD_FILE_EXT = ".archive";
  * The extension of a RedScript file
  */
 const REDSCRIPT_FILE_EXT = ".reds";
-/**
- * The extension of a lua/CET file
- */
-const LUA_FILE_EXT = ".lua";
 
 const PRIORITY_STARTING_NUMBER = 30; // Why? Fomod is 20, then.. who knows? Don't go over 99
 
@@ -404,20 +400,11 @@ export const testAnyOtherModFallback: Vortex.TestSupported = (
   const correctGame = gameId === GAME_ID;
   log("info", "Checking bad structure of mod for a game: ", gameId);
   if (!correctGame) {
-    // no mods?
-    const supported = false;
     return Promise.resolve({
-      supported,
+      supported: false,
       requiredFiles: [],
     });
   }
-
-  // Make sure we're able to support this mod.
-  const hasArchiveMod =
-    files.find(
-      (file: string) => path.extname(file).toLowerCase() === MOD_FILE_EXT,
-    ) !== undefined;
-  log("debug", "Probably archives: ", hasArchiveMod);
 
   const hasIniMod = files.some(matchIniFile);
   log("debug", "Probably INI mods: ", hasIniMod);
@@ -428,25 +415,17 @@ export const testAnyOtherModFallback: Vortex.TestSupported = (
     ) !== undefined;
   log("debug", "Possibly RedScripts: ", hasRedScript);
 
-  const hasCetScript =
-    files.find(
-      (file: string) => path.extname(file).toLowerCase() === LUA_FILE_EXT,
-    ) !== undefined;
-  log("debug", "Possible CET Scripts: ", hasCetScript);
-
-  if (hasArchiveMod || hasIniMod || hasRedScript || hasCetScript) {
-    const supported = true;
+  if (hasIniMod || hasRedScript) {
     log("info", "mod supported by this installer");
     return Promise.resolve({
-      supported,
+      supported: true,
       requiredFiles: [],
     });
   }
 
-  const supported = false;
   log("warn", "I dunno. Can't do nothing about this.");
   return Promise.resolve({
-    supported,
+    supported: false,
     requiredFiles: [],
   });
 };
@@ -576,22 +555,6 @@ export const installAnyModWithBasicFixes: Vortex.InstallFunc = (
   // Grab the archive name for putting CET files and Redscript into
   const archiveName = path.basename(destinationPath, ".installing");
 
-  // gather the archive files.
-  const someArchiveModFile = files.find(
-    (file: string) => path.extname(file).toLowerCase() === MOD_FILE_EXT,
-  );
-  let filteredArchives: string[];
-  if (someArchiveModFile !== undefined) {
-    const theArchivePathAsIs = path.dirname(someArchiveModFile);
-    filteredArchives = files.filter(
-      (file: string) =>
-        path.dirname(file) === theArchivePathAsIs ||
-        path.extname(file).toLowerCase() === MOD_FILE_EXT,
-    );
-  } else {
-    filteredArchives = [];
-  }
-
   // Gather any INI files
   const iniModFiles = files.filter(matchIniFile);
 
@@ -617,15 +580,6 @@ export const installAnyModWithBasicFixes: Vortex.InstallFunc = (
   //       !filteredCet.includes(file);
   //   });
 
-  // Set destination to be 'archive/pc/mod/[file].archive'
-  log("info", "Correcting archive files: ", filteredArchives);
-  const archiveFileInstructions = filteredArchives.map((file: string) => ({
-    type: "copy",
-    source: file,
-    destination: path.join(ARCHIVE_MOD_PATH, path.basename(file)),
-  }));
-  log("debug", "Installing archive files with: ", archiveFileInstructions);
-
   log("info", "Correcting INI mod files: ", iniModFiles);
   const iniModInstructions = iniModFiles.map((file) => ({
     type: "copy",
@@ -648,7 +602,6 @@ export const installAnyModWithBasicFixes: Vortex.InstallFunc = (
   //   log("debug", "Installing everything else with: ", cetScriptInstructions);
 
   const instructions = [].concat(
-    archiveFileInstructions,
     iniModInstructions,
     redScriptInstructions,
     // everythingLeftOverInstructions

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -775,11 +775,4 @@ export const installerPipeline: InstallerWithPriority[] = [
     testSupported: testAnyOtherModFallback,
     install: installAnyModWithBasicFixes,
   },
-  // Quite possible we won’t need this one
-  {
-    type: InstallerType.NotSupported,
-    id: "cp2077-not-supported",
-    testSupported: notSupportedModType,
-    install: notInstallableMod,
-  },
 ].reduce(addPriorityFrom(PRIORITY_STARTING_NUMBER), []);

--- a/test/unit/installer-fix.test.ts
+++ b/test/unit/installer-fix.test.ts
@@ -1,6 +1,9 @@
+import * as path from "path";
 import { InstallerType } from "../../src/installers";
-import { ArchiveOnly, CetMod } from "./mods.example";
-import { matchInstaller } from "./utils.helper";
+import { AllModTypes, ArchiveOnly, CetMod } from "./mods.example";
+import { getFallbackInstaller, matchInstaller } from "./utils.helper";
+
+const fakeInstallDir = path.join("C:\\magicstuff\\maybemodziporsomething");
 
 describe("Transforming modules to instructions", () => {
   describe("CET mods", () => {
@@ -12,7 +15,7 @@ describe("Transforming modules to instructions", () => {
 
         const installResult = await installer.install(
           mod.inFiles,
-          null,
+          fakeInstallDir,
           null,
           null,
         );
@@ -30,12 +33,31 @@ describe("Transforming modules to instructions", () => {
 
         const installResult = await installer.install(
           mod.inFiles,
-          null,
+          fakeInstallDir,
           null,
           null,
         );
 
         expect(installResult.instructions).toEqual(mod.outInstructions);
+      });
+    });
+  });
+
+  describe("fallback for anything that doesn't match other installers", () => {
+    const fallbackInstaller = getFallbackInstaller();
+
+    AllModTypes.forEach((type) => {
+      type.forEach(async (mod, desc) => {
+        test(`doesn’t produce any instructions handled by specific installers when ${desc}`, async () => {
+          const installResult = await fallbackInstaller.install(
+            mod.inFiles,
+            fakeInstallDir,
+            null,
+            null,
+          );
+
+          expect(installResult.instructions).toEqual([]);
+        });
       });
     });
   });

--- a/test/unit/installer-select.test.ts
+++ b/test/unit/installer-select.test.ts
@@ -1,16 +1,15 @@
-import { GameEntryNotFound } from "vortex-api/lib/types/IGameStore";
+import { InstallerType } from "../../src/installers";
+import { AllModTypes, ArchiveOnly, CetMod } from "./mods.example";
 import {
-  installerPipeline,
-  InstallerType,
-  InstallerWithPriority,
-} from "../../src/installers";
-import { ArchiveOnly, CetMod } from "./mods.example";
-import { matchInstaller } from "./utils.helper";
+  getFallbackInstaller,
+  matchInstaller,
+  matchSpecific,
+} from "./utils.helper";
 
 describe("Selecting the installer for a mod type", () => {
   describe("CET mods", () => {
-    CetMod.forEach(async (mod, kind) => {
-      test(`selects the CET installer when ${kind}`, async () => {
+    CetMod.forEach(async (mod, desc) => {
+      test(`selects the CET installer when ${desc}`, async () => {
         const installer = await matchInstaller(mod.inFiles);
         expect(installer).toBeDefined();
         expect(installer.type).toBe(InstallerType.CET);
@@ -19,11 +18,24 @@ describe("Selecting the installer for a mod type", () => {
   });
 
   describe("archive-only mods", () => {
-    ArchiveOnly.forEach(async (mod, kind) => {
-      test(`selects the archive-only installer when ${kind}`, async () => {
+    ArchiveOnly.forEach(async (mod, desc) => {
+      test(`selects the archive-only installer when ${desc}`, async () => {
         const installer = await matchInstaller(mod.inFiles);
         expect(installer).toBeDefined();
         expect(installer.type).toBe(InstallerType.ArchiveOnly);
+      });
+    });
+  });
+
+  describe("fallback for anything that doesn't match other installers", () => {
+    const fallbackInstaller = getFallbackInstaller();
+
+    AllModTypes.forEach((type) => {
+      type.forEach(async (mod, desc) => {
+        test(`doesn’t match mod matched by specific installer when ${desc}`, async () => {
+          const result = await matchSpecific(fallbackInstaller, mod.inFiles);
+          expect(result.supported).toBeFalsy();
+        });
       });
     });
   });

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -263,3 +263,5 @@ export const ArchiveOnly = new Map<string, ExampleMod>(
     },
   }), // object
 );
+
+export const AllModTypes = [CetMod, ArchiveOnly];

--- a/test/unit/utils.helper.ts
+++ b/test/unit/utils.helper.ts
@@ -1,10 +1,25 @@
-import { installerPipeline } from "../../src/installers";
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-restricted-syntax */
+import { installerPipeline, InstallerType } from "../../src/installers";
 
-const GAME_ID = "cyberpunk2077";
+export const GAME_ID = "cyberpunk2077";
+
+export const getFallbackInstaller = () => {
+  const fallbackInstaller = installerPipeline[installerPipeline.length - 1];
+
+  test("last installer in pipeline is the fallback", () => {
+    expect(fallbackInstaller.type).toBe(InstallerType.FallbackForOther);
+  });
+
+  return fallbackInstaller;
+};
+
+export const matchSpecific = async (installer, modFiles: string[]) =>
+  installer.testSupported(modFiles, GAME_ID);
 
 export const matchInstaller = async (modFiles: string[]) => {
   for (const installer of installerPipeline) {
-    const result = await installer.testSupported(modFiles, GAME_ID);
+    const result = await matchSpecific(installer, modFiles);
 
     if (result.supported) {
       return installer;


### PR DESCRIPTION
Since we’re handling CET and ArchiveOnly specifically now, don't support them in the fallback.

We may want to convert the fallback to a flat copy at some point, but for now this seems more straightforward.