### PR TITLE
Internal Pipeline Installer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import path from "path";
-import * as vapi from "vortex-api"; // eslint-disable-line import/no-extraneous-dependencies
+import * as vortexApi from "vortex-api"; // eslint-disable-line import/no-extraneous-dependencies
 
 // Our stuff
 import { EPICAPP_ID, GAME_ID, GOGAPP_ID, STEAMAPP_ID } from "./index.metadata";
-import { installerPipeline, wrapTestSupported, wrapInstall } from "./installers";
+import { wrapTestSupported, wrapInstall, internalPipelineInstaller } from "./installers";
 import { VortexExtensionContext, VortexGameStoreEntry } from "./vortex-wrapper";
 
 const moddingTools = [
@@ -21,16 +21,17 @@ const moddingTools = [
 ];
 
 export const findGame = () =>
-  vapi.util.GameStoreHelper.findByAppId([STEAMAPP_ID, GOGAPP_ID, EPICAPP_ID]).then(
+  vortexApi.util.GameStoreHelper.findByAppId([STEAMAPP_ID, GOGAPP_ID, EPICAPP_ID]).then(
     (game: VortexGameStoreEntry) => game.gamePath,
   );
 
 const requiresGoGLauncher = () =>
-  vapi.util.GameStoreHelper.isGameInstalled(GOGAPP_ID, "gog").then((gog) =>
+  vortexApi.util.GameStoreHelper.isGameInstalled(GOGAPP_ID, "gog").then((gog) =>
     gog ? { launcher: "gog", addInfo: GOGAPP_ID } : undefined,
   );
 
-const prepareForModding = (discovery) => vapi.fs.readdirAsync(path.join(discovery.path));
+const prepareForModding = (discovery) =>
+  vortexApi.fs.readdirAsync(path.join(discovery.path));
 
 // This is the main function Vortex will run when detecting the game extension.
 const main = (vortex: VortexExtensionContext) => {
@@ -59,14 +60,12 @@ const main = (vortex: VortexExtensionContext) => {
     },
   });
 
-  installerPipeline.forEach((installer) => {
-    vortex.registerInstaller(
-      installer.id,
-      installer.priority,
-      wrapTestSupported(vortex, vapi, installer),
-      wrapInstall(vortex, vapi, installer),
-    );
-  });
+  vortex.registerInstaller(
+    internalPipelineInstaller.id,
+    internalPipelineInstaller.priority,
+    wrapTestSupported(vortex, vortexApi, internalPipelineInstaller),
+    wrapInstall(vortex, vortexApi, internalPipelineInstaller),
+  );
 
   return true;
 };

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -797,13 +797,7 @@ export const installRedscriptMod: VortexWrappedInstallFunc = async (
 
   const installable = [hasToplevelReds, hasBasedirReds, hasCanonReds].filter(trueish);
 
-  if (installable.length < 1) {
-    const message = "No Redscript found, should never get here.";
-    log("error", `Redscript Mod installer: ${message}`, files);
-    return Promise.reject(new Error(message));
-  }
-
-  if (installable.length > 1) {
+  if (installable.length !== 1) {
     return useFallbackOrFailBasedOnUserDecision(api, InstallerType.Redscript, fileTree);
   }
 

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -1544,43 +1544,43 @@ const addPriorityFrom = (start: number) => {
 const installers: Installer[] = [
   {
     type: InstallerType.CoreCET,
-    id: "cp2077-core-cet-mod",
+    id: InstallerType.CoreCET,
     testSupported: testForCetCore,
     install: installCetCore,
   },
   {
     type: InstallerType.CoreRedscript,
-    id: "cp2077-core-redscript-mod",
+    id: InstallerType.CoreRedscript,
     testSupported: testForRedscriptCore,
     install: installRedscriptCore,
   },
   {
     type: InstallerType.CoreRed4ext,
-    id: "cp2077-core-red4ext-mod",
+    id: InstallerType.CoreRed4ext,
     testSupported: testRed4ExtCore,
     install: installRed4ExtCore,
   },
   {
     type: InstallerType.CoreCSVMerge,
-    id: "cp2077-core-csvmerge-mod",
+    id: InstallerType.CoreCSVMerge,
     testSupported: testCoreCsvMerge,
     install: installCoreCsvMerge,
   },
   {
     type: InstallerType.CoreWolvenKit,
-    id: "cp2077-core-wolvenkit-mod",
+    id: InstallerType.CoreWolvenKit,
     testSupported: testCoreWolvenKitCli,
     install: installCoreWolvenkit,
   },
   {
     type: InstallerType.ASI,
-    id: "cp2077-asi-mod",
+    id: InstallerType.ASI,
     testSupported: testForAsiMod,
     install: installAsiMod,
   },
   {
     type: InstallerType.MultiType,
-    id: "cp2077-multitype-mod",
+    id: InstallerType.MultiType,
     testSupported: testForMultiTypeMod,
     install: installMultiTypeMod,
   },
@@ -1595,19 +1595,19 @@ const installers: Installer[] = [
   // },
   {
     type: InstallerType.CET,
-    id: "cp2077-cet-mod",
+    id: InstallerType.CET,
     testSupported: testForCetMod,
     install: installCetMod,
   },
   {
     type: InstallerType.Redscript,
-    id: "cp2077-redscript-mod",
+    id: InstallerType.Redscript,
     testSupported: testForRedscriptMod,
     install: installRedscriptMod,
   },
   {
     type: InstallerType.Red4Ext,
-    id: "cp2077-red4ext-mod",
+    id: InstallerType.Red4Ext,
     testSupported: testForRed4ExtMod,
     install: installRed4ExtMod,
   },
@@ -1627,7 +1627,7 @@ const installers: Installer[] = [
 */
   {
     type: InstallerType.INI,
-    id: "cp2077-ini-mod",
+    id: InstallerType.INI,
     testSupported: testForIniMod,
     install: installIniMod,
   },
@@ -1653,19 +1653,19 @@ const installers: Installer[] = [
 
   {
     type: InstallerType.Json,
-    id: "cp2077-json-mod",
+    id: InstallerType.Json,
     testSupported: testForJsonMod,
     install: installJsonMod,
   },
   {
     type: InstallerType.ArchiveOnly,
-    id: "cp2077-basic-archive-mod",
+    id: InstallerType.ArchiveOnly,
     testSupported: testForArchiveOnlyMod,
     install: installArchiveOnlyMod,
   },
   {
     type: InstallerType.Fallback,
-    id: "cp2077-fallback-for-others-mod",
+    id: InstallerType.Fallback,
     testSupported: testAnyOtherModFallback,
     install: installAnyModFallback,
   },

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -4,6 +4,9 @@ import {
 } from "./vortex-wrapper";
 
 export enum InstallerType {
+  // Meta-installer, won't be in the pipeline itself
+  Pipeline = `V2077 Installer Pipeline`,
+  //
   CoreCET = "Core/CET", // #32
   CoreRedscript = "Core/Redscript", // #32
   CoreRed4ext = "Core/Red4ext", // #32

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -7,26 +7,26 @@ export enum InstallerType {
   // Meta-installer, won't be in the pipeline itself
   Pipeline = `V2077 Installer Pipeline`,
   //
-  CoreCET = "Core/CET", // #32
-  CoreRedscript = "Core/Redscript", // #32
-  CoreRed4ext = "Core/Red4ext", // #32
-  CoreCSVMerge = "Core/CSVMerge", // #32
-  CoreWolvenKit = "Core/WolvenKitCLI", // #32
-  ASI = "ASI",
-  MultiType = "Multiple Types Combined", // #79
-  CET = "CET",
-  Redscript = "Redscript",
-  Red4Ext = "Red4ext", // #5
-  TweakDB = "TweakDB", // #6
-  AXL = "AXL", // #28
-  INI = "INI", // #29
-  Config = "Config", // #30
-  Reshade = "Reshade", // #8
-  LUT = "LUT", // #31
-  Json = "JSON",
-  ArchiveOnly = "ArchiveOnly",
-  Fallback = "FallbackForOther",
-  NotSupported = "[Trying to install something not supported]",
+  CoreCET = `Core/CET Installer`,
+  CoreRedscript = `Core/Redscript Installer`,
+  CoreRed4ext = `Core/Red4ext Installer`,
+  CoreCSVMerge = `Core/CSVMerge Installer`,
+  CoreWolvenKit = `Core/WolvenKitCLI Installer`,
+  ASI = `ASI Installer`,
+  MultiType = `MultiType Installer`,
+  CET = `CET Installer`,
+  Redscript = `Redscript Installer`,
+  Red4Ext = `Red4ext Installer`,
+  TweakDB = `TweakDB Installer`,
+  AXL = `AXL Installer`,
+  INI = `INI Installer`,
+  Config = `Config Installer`,
+  Reshade = `Reshade Installer`,
+  LUT = `LUT Installer`,
+  Json = `JSON Installer`,
+  ArchiveOnly = `ArchiveOnly Installer`,
+  Fallback = `Fallback Installer`,
+  NotSupported = `<NONEXISTING INSTALLER - THIS SHOULD NOT BE GETTING USED>`,
 }
 
 export interface Installer {

--- a/test/unit/installer-fix.test.ts
+++ b/test/unit/installer-fix.test.ts
@@ -5,7 +5,6 @@ import { fileTreeFromPaths } from "../../src/filetree";
 import { internalPipelineInstaller } from "../../src/installers";
 import { VortexApi, VortexDialogResult } from "../../src/vortex-wrapper";
 import {
-  AllExpectedInstallFailures,
   AllExpectedInstallPromptables,
   AllModTypes,
   FAKE_STAGING_PATH,
@@ -121,40 +120,6 @@ describe("Transforming modules to instructions", () => {
           );
 
           await expectation.rejects.toThrowError(new Error(mod.cancelErrorMessage));
-        });
-      });
-    });
-  });
-
-  AllExpectedInstallFailures.forEach((examples, set) => {
-    describe(`install attempts that should fail, ${set}`, () => {
-      examples.forEach(async (mod, desc) => {
-        test(`rejects with an error when ${desc}`, async () => {
-          let message;
-
-          try {
-            // wow
-            await internalPipelineInstaller.install(
-              mockVortexApi,
-              mockVortexLog,
-              mod.inFiles,
-              fileTreeFromPaths(mod.inFiles),
-              FAKE_STAGING_PATH,
-              GAME_ID,
-              null,
-            );
-          } catch (error) {
-            // such type
-            message = error.message;
-          } finally {
-            if (message) {
-              // much fp
-              expect(message).toEqual(mod.failure);
-            } else {
-              // very safety
-              expect(message, `should've rejected for ${desc}`).toEqual(mod.failure);
-            }
-          }
         });
       });
     });

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -82,6 +82,12 @@ const ARCHIVE_PREFIXES = pathHierarchyFor(ARCHIVE_PREFIX);
 const ASI_PREFIX = ASI_MOD_PATH;
 const ASI_PREFIXES = pathHierarchyFor(ASI_PREFIX);
 
+// Some loggy helpers
+
+const PIPELINE_LOG = `${InstallerType.Pipeline}: installation error: `;
+const expectedUserCancelMessageFor = (installerType: InstallerType) =>
+  `${PIPELINE_LOG}${installerType}: user chose to cancel installation on conflict`;
+
 export const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     coreCetInstall: {
@@ -674,7 +680,7 @@ export const RedscriptModShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: "Redscript: user chose to cancel installation on conflict",
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
     },
   }),
 );
@@ -901,7 +907,7 @@ export const Red4ExtModShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: "Red4ext: user chose to cancel installation on conflict",
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Red4Ext),
     },
     red4extWithExtraArchivesInWrongPlacePromptsOnConflictForFallback: {
       expectedInstallerType: InstallerType.Red4Ext,
@@ -924,7 +930,7 @@ export const Red4ExtModShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: "Red4ext: user chose to cancel installation on conflict",
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Red4Ext),
     },
   }),
 );
@@ -1136,7 +1142,7 @@ export const ArchiveOnlyModShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: "ArchiveOnly: user chose to cancel installation on conflict",
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.ArchiveOnly),
     },
   }),
 );
@@ -1430,7 +1436,7 @@ export const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: `${InstallerType.Fallback}: user chose to cancel installation on conflict`,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Fallback),
     },
     invalidModContainingRandomFiles: {
       expectedInstallerType: InstallerType.Fallback,
@@ -1449,7 +1455,7 @@ export const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: `${InstallerType.Fallback}: user chose to cancel installation on conflict`,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Fallback),
     },
     invalidModWithDeepInvalidPath: {
       expectedInstallerType: InstallerType.Fallback,
@@ -1466,7 +1472,7 @@ export const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: `${InstallerType.Fallback}: user chose to cancel installation on conflict`,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Fallback),
     },
   }), // object
 );
@@ -1745,7 +1751,7 @@ export const MultiTypeModShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: `${InstallerType.MultiType}: user chose to cancel installation on conflict`,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.MultiType),
     },
     multitypeWithCanonAndToplevelRedsPromptsOnConflict: {
       expectedInstallerType: InstallerType.MultiType,
@@ -1811,7 +1817,7 @@ export const MultiTypeModShouldPromptForInstall = new Map<
         },
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: `${InstallerType.MultiType}: user chose to cancel installation on conflict`,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.MultiType),
     },
   }),
 );

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -682,15 +682,19 @@ export const RedscriptModShouldPromptForInstall = new Map<
       cancelLabel: InstallChoices.Cancel,
       cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
     },
-  }),
-);
-
-export const RedscriptModShouldFailInInstall = new Map<string, ExampleFailingMod>(
-  Object.entries({
-    redsScriptInTopLevelDirShouldFail: {
+    redsWithRedsInToplevelSubdirPromptsOnConflictForFallback: {
       expectedInstallerType: InstallerType.Redscript,
       inFiles: [path.join(`rexmod/script.reds`)],
-      failure: "No Redscript found, should never get here.",
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        {
+          type: "copy",
+          source: path.join(`rexmod/script.reds`),
+          destination: path.join(`rexmod/script.reds`),
+        },
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
     },
   }),
 );
@@ -1859,11 +1863,5 @@ export const AllExpectedInstallPromptables = new Map<
     Red4ExtModShouldPromptForInstall,
     ArchiveOnlyModShouldPromptForInstall,
     FallbackForNonMatchedAndInvalidShouldPromptForInstall,
-  }),
-);
-
-export const AllExpectedInstallFailures = new Map<string, ExampleFailingModCategory>(
-  Object.entries({
-    RedscriptModShouldFailInInstall,
   }),
 );

--- a/test/unit/utils.helper.ts
+++ b/test/unit/utils.helper.ts
@@ -23,8 +23,14 @@ export const mockVortexApi: MockProxy<VortexApi> = mockDeep<VortexApi>();
 export const mockVortexLog = jest.fn();
 
 if (process.env.DEBUG) {
-  // eslint-disable-next-line no-console
-  mockVortexLog.mockImplementation((...args) => console.log("Log:", args));
+  mockVortexLog.mockImplementation((...args) =>
+    // eslint-disable-next-line no-console
+    console.log(`log():`, args),
+  );
+  mockVortexApi.log.mockImplementation((...args) =>
+    // eslint-disable-next-line no-console
+    console.log(`api.log:`, args),
+  );
 }
 
 export const getFallbackInstaller = () => {


### PR DESCRIPTION
**NB: we currently always return true in `testSupport`. This means that no other extensions can run after us.**

- Added `internalPipelineInstaller` to give us full control of the install process, and the possibility to maintain some kind of state through the pipeline.
- Driver: to support 'gift-wrapped' mods, we can now unwrap the extra toplevel directory *once*, not everywhere in the code.
- `internalPipelineInstaller.testSupport` always returns true
- `internalPipelineInstaller.install` actually loops through the pipeline to first `testSupport` to find the right installer, and then uses that to `install`.
- Logic for the individual installers SHOULD remain exactly the same

Closes #101 