### PR TITLE
✨ Config XML Support

### DIFF
--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -77,6 +77,38 @@ export const promptUserToInstallOrCancel = async (
   return installDecision;
 };
 
+export const promptUserOnProtectedPaths = async (
+  api: VortexApi,
+  installerType: InstallerType,
+  protectedPaths: string[],
+): Promise<InstallDecision> => {
+  const explanationForUser = `
+    This mod contains some paths that I consider protected! They might be
+    either critical game files, or for example configuration files that
+    you may have customized or that other mods might also have modified.
+
+    **This does not mean there's a problem with the mod, just that I
+    want to make sure you're ready to proceed.**
+
+    Review the files below to make sure it's okay to install these and
+    that you've backed up your config files etc. before you enable the mod :)
+
+    (Just installing this mod won't overwrite the files yet, that's only
+    when you enable the mod - if you use the auto-enable setting, you
+    should make your backups before proceeding, otherwise you can do it later.)
+
+    These are the protected paths this mod will write to:
+    \`\`\`
+    ${protectedPaths.join(`\n`)}
+    \`\`\``;
+
+  return promptUserToInstallOrCancel(
+    api,
+    `Mod Contains Protected Paths`,
+    explanationForUser,
+  );
+};
+
 export const promptUserOnUnresolvableLayout = async (
   api: VortexApi,
   installerType: InstallerType,

--- a/src/installer.config.ini-reshade.ts
+++ b/src/installer.config.ini-reshade.ts
@@ -2,13 +2,13 @@ import path from "path";
 import fs from "fs";
 import { FileTree } from "./filetree";
 import {
-  INI_MOD_EXT,
+  CONFIG_INI_MOD_EXTENSION,
   CET_MOD_CANONICAL_INIT_FILE,
   REDS_MOD_CANONICAL_EXTENSION,
   CET_GLOBAL_INI,
-  RESHADE_MOD_PATH,
-  INI_MOD_PATH,
-  RESHADE_SHADERS_DIR,
+  CONFIG_RESHADE_MOD_BASEDIR,
+  CONFIG_INI_MOD_BASEDIR,
+  CONFIG_RESHADE_MOD_SHADER_DIRNAME,
 } from "./installers.layouts";
 import {
   VortexLogFunc,
@@ -29,7 +29,7 @@ const testForReshadeFile = (
 
   const fileToExamine = path.join(
     folder,
-    files.find((file: string) => path.extname(file) === INI_MOD_EXT),
+    files.find((file: string) => path.extname(file) === CONFIG_INI_MOD_EXTENSION),
   );
 
   const data = fs.readFileSync(fileToExamine, { encoding: "utf8" });
@@ -58,7 +58,7 @@ export const testForIniMod: VortexWrappedTestSupportedFunc = (
   _fileTree: FileTree,
 ): Promise<VortexTestResult> => {
   const filtered = files.filter(
-    (file: string) => path.extname(file).toLowerCase() === INI_MOD_EXT,
+    (file: string) => path.extname(file).toLowerCase() === CONFIG_INI_MOD_EXTENSION,
   );
 
   if (filtered.length === 0) {
@@ -106,7 +106,7 @@ export const installIniMod: VortexWrappedInstallFunc = (
   // This installer gets called for both reshade and "normal" ini mods
 
   const allIniModFiles = files.filter(
-    (file: string) => path.extname(file) === INI_MOD_EXT,
+    (file: string) => path.extname(file) === CONFIG_INI_MOD_EXTENSION,
   );
 
   const reshade = testForReshadeFile(log, allIniModFiles, _destinationPath);
@@ -117,8 +117,8 @@ export const installIniMod: VortexWrappedInstallFunc = (
   const iniFileInstructions = allIniModFiles.map((file: string) => {
     const fileName = path.basename(file);
     const dest = reshade
-      ? path.join(RESHADE_MOD_PATH, path.basename(file))
-      : path.join(INI_MOD_PATH, fileName);
+      ? path.join(CONFIG_RESHADE_MOD_BASEDIR, path.basename(file))
+      : path.join(CONFIG_INI_MOD_BASEDIR, fileName);
 
     return {
       type: "copy",
@@ -128,7 +128,8 @@ export const installIniMod: VortexWrappedInstallFunc = (
   });
 
   const shaderFiles = files.filter(
-    (file: string) => file.includes(RESHADE_SHADERS_DIR) && !file.endsWith(path.sep),
+    (file: string) =>
+      file.includes(CONFIG_RESHADE_MOD_SHADER_DIRNAME) && !file.endsWith(path.sep),
   );
 
   let shaderInstructions = [];
@@ -137,9 +138,9 @@ export const installIniMod: VortexWrappedInstallFunc = (
     log("info", "Installing shader files: ", shaderFiles);
     shaderInstructions = shaderFiles.map((file: string) => {
       const regex = /.*reshade-shaders/;
-      const fileName = file.replace(regex, RESHADE_SHADERS_DIR);
+      const fileName = file.replace(regex, CONFIG_RESHADE_MOD_SHADER_DIRNAME);
       // log("info", "Shader dir Found. Processing: ", fileName);
-      const dest = path.join(RESHADE_MOD_PATH, fileName);
+      const dest = path.join(CONFIG_RESHADE_MOD_BASEDIR, fileName);
       // log("debug", "Shader file: ", dest);
       return {
         type: "copy",

--- a/src/installer.config.json.ts
+++ b/src/installer.config.json.ts
@@ -1,9 +1,9 @@
 import path from "path";
 import { FileTree } from "./filetree";
 import {
-  JSON_FILE_EXT,
+  CONFIG_JSON_MOD_EXTENSION,
   CET_MOD_CANONICAL_PATH_PREFIX,
-  KNOWN_JSON_FILES,
+  CONFIG_JSON_MOD_KNOWN_FILES,
 } from "./installers.layouts";
 import {
   VortexWrappedTestSupportedFunc,
@@ -21,7 +21,7 @@ export const testForJsonMod: VortexWrappedTestSupportedFunc = (
   _fileTree: FileTree,
 ): Promise<VortexTestResult> => {
   const filtered = files.filter(
-    (file: string) => path.extname(file).toLowerCase() === JSON_FILE_EXT,
+    (file: string) => path.extname(file).toLowerCase() === CONFIG_JSON_MOD_EXTENSION,
   );
   if (filtered.length === 0) {
     return Promise.resolve({
@@ -62,7 +62,9 @@ export const testForJsonMod: VortexWrappedTestSupportedFunc = (
       return Promise.reject(new Error(message));
     }
   } else if (
-    filtered.some((file: string) => KNOWN_JSON_FILES[path.basename(file)] === undefined)
+    filtered.some(
+      (file: string) => CONFIG_JSON_MOD_KNOWN_FILES[path.basename(file)] === undefined,
+    )
   ) {
     log("error", "Found JSON files that aren't part of the game.");
     return Promise.reject(new Error("Found JSON files that aren't part of the game."));
@@ -98,8 +100,8 @@ export const installJsonMod: VortexWrappedInstallFunc = (
 
     let instPath = file;
 
-    if (KNOWN_JSON_FILES[fileName] !== undefined) {
-      instPath = KNOWN_JSON_FILES[fileName];
+    if (CONFIG_JSON_MOD_KNOWN_FILES[fileName] !== undefined) {
+      instPath = CONFIG_JSON_MOD_KNOWN_FILES[fileName];
 
       log("debug", "instPath set as ", instPath);
       movedJson = movedJson || file !== instPath;

--- a/src/installer.multitype.ts
+++ b/src/installer.multitype.ts
@@ -1,5 +1,3 @@
-// MultiType installer
-
 import { FileTree, fileCount } from "./filetree";
 import {
   detectExtraArchiveLayouts,
@@ -23,7 +21,11 @@ import {
   detectAllowedTweakXLLayouts,
   tweakXLAllowedInMultiInstructions,
 } from "./installer.tweak-xl";
-import { LayoutToInstructions } from "./installers.layouts";
+import {
+  configXmlAllowedInMultiInstructions,
+  detectAllowedConfigXmlLayouts,
+} from "./installer.xml";
+import { LayoutToInstructions, NotAllowed } from "./installers.layouts";
 import { makeSyntheticName, useAllMatchingLayouts } from "./installers.shared";
 import { InstallerType } from "./installers.types";
 import { trueish } from "./installers.utils";
@@ -47,7 +49,9 @@ export const testForMultiTypeMod: VortexWrappedTestSupportedFunc = (
   const hasBasedirRedscript = detectRedscriptBasedirLayout(fileTree);
   const hasCanonRed4Ext = detectRed4ExtCanonOnlyLayout(fileTree);
   const hasBasedirRed4Ext = detectRed4ExtBasedirLayout(fileTree);
-  const hasCanonTweakXL = detectAllowedTweakXLLayouts(fileTree);
+
+  const hasAllowedConfigXml = detectAllowedConfigXmlLayouts(fileTree);
+  const hasAllowedTweakXL = detectAllowedTweakXLLayouts(fileTree);
 
   const hasExtraArchives = detectExtraArchiveLayouts(fileTree);
 
@@ -56,12 +60,13 @@ export const testForMultiTypeMod: VortexWrappedTestSupportedFunc = (
   // additional checks.
   const hasAtLeastTwoTypes =
     [
+      hasAllowedConfigXml,
       hasCanonCet,
       hasCanonRedscript,
       hasBasedirRedscript,
       hasCanonRed4Ext,
       hasBasedirRed4Ext,
-      hasCanonTweakXL,
+      hasAllowedTweakXL,
     ].filter(trueish).length > 1;
 
   // For now, let's define these specifically. Should also move
@@ -69,7 +74,7 @@ export const testForMultiTypeMod: VortexWrappedTestSupportedFunc = (
   // I think we might also be able to unify these two if we don't
   // need to worry about the archive special cases..)
   const hasValidExtraArchives =
-    hasExtraArchives && (hasCanonTweakXL || hasCanonRed4Ext || hasBasedirRed4Ext);
+    hasExtraArchives && (hasAllowedTweakXL || hasCanonRed4Ext || hasBasedirRed4Ext);
 
   if (!hasAtLeastTwoTypes && !hasValidExtraArchives) {
     api.log(`debug`, `${InstallerType.MultiType}: no multitype match`);
@@ -84,28 +89,43 @@ export const testForMultiTypeMod: VortexWrappedTestSupportedFunc = (
   });
 };
 
-export const installMultiTypeMod: VortexWrappedInstallFunc = (
+export const installMultiTypeMod: VortexWrappedInstallFunc = async (
   api: VortexApi,
   _log: VortexLogFunc,
   _files: string[],
   fileTree: FileTree,
   destinationPath: string,
 ): Promise<VortexInstallResult> => {
+  const me = InstallerType.MultiType;
+
+  // This can fail (as may others in the future), so we
+  // break the usual linear execution by handling this
+  // case first since it 1) it's much easier to handle
+  // and 2) it's waste to process the rest if this fails.
+  const xmlInstructions = await configXmlAllowedInMultiInstructions(api, fileTree);
+
+  if (xmlInstructions === NotAllowed.CanceledByUser) {
+    const cancelMessage = `${me}: user has canceled installation for some part of this mod. Can't proceed safely, canceling entirely.`;
+
+    api.log(`error`, cancelMessage);
+    return Promise.reject(new Error(cancelMessage));
+  }
+
   // Should extract this to wrapper..
   const modName = makeSyntheticName(destinationPath);
 
-  // This should be more robust. Currently we kinda rely
-  // on it being very unlikely that these kinds of mods
-  // are broken in ways like having canon and basedir
-  // stuff but that's not guaranteed.
+  // This should be made more robust, and much clearer.
+  // Currently we rely on these layouts to be exclusive
+  // or unlikely to break because of the order chosen
+  // here.
+  //
+  // The XML above and Archive + TweakXL below use an
+  // explicitly intended for contextless use like here,
+  // so we can rely on them.
+  //
+  // Change the rest to work this way.
   //
   // Defect: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/96
-
-  // Also notable: Basedirs currently *override* Canon.
-  // This is probably the desired behavior but I dunno
-  // if we could at least make it somehow more obvious
-  // in the naming scheme.. it's clearer in specific
-  // installers where we choose one layout only.
   const allInstructionSets: LayoutToInstructions[] = [
     cetCanonLayout,
     redscriptBasedirLayout,
@@ -121,16 +141,26 @@ export const installMultiTypeMod: VortexWrappedInstallFunc = (
     allInstructionSets,
   );
 
-  const allInstructionsWeProduced = allInstructionsPerLayout.flatMap(
-    (i) => i.instructions,
+  const allInstructionsDirectedByUs = allInstructionsPerLayout.flatMap(
+    (result) => result.instructions,
   );
 
+  // Handling multiple async/await is just horrible in JS/TS
+  // so we simply don't do that. Sure, it'd be more 'elegant'
+  // but this is /better/.
+  const archiveInstructions = extraCanonArchiveInstructions(api, fileTree);
+
+  const tweakXLInstructions = tweakXLAllowedInMultiInstructions(api, fileTree);
+
   const allInstructions = [
-    ...allInstructionsWeProduced,
-    ...extraCanonArchiveInstructions(api, fileTree).instructions,
-    ...tweakXLAllowedInMultiInstructions(api, fileTree).instructions,
+    ...allInstructionsDirectedByUs,
+    ...xmlInstructions.instructions,
+    ...archiveInstructions.instructions,
+    ...tweakXLInstructions.instructions,
   ];
 
+  // Need to handle docs and images and whatnot here maybe?
+  // Defect: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/133
   const haveFilesOutsideSelectedInstructions =
     allInstructions.length !== fileCount(fileTree);
 

--- a/src/installer.xml.ts
+++ b/src/installer.xml.ts
@@ -1,0 +1,222 @@
+import path from "path";
+import {
+  VortexApi,
+  VortexLogFunc,
+  VortexTestResult,
+  VortexWrappedInstallFunc,
+  VortexWrappedTestSupportedFunc,
+  VortexProgressDelegate,
+  VortexInstallResult,
+} from "./vortex-wrapper";
+import { FileTree, filesIn, FILETREE_ROOT } from "./filetree";
+import {
+  MaybeInstructions,
+  NoInstructions,
+  InvalidLayout,
+  Instructions,
+  NoLayout,
+  CONFIG_XML_MOD_EXTENSION,
+  CONFIG_XML_MOD_BASEDIR,
+  CONFIG_XML_MOD_PROTECTED_FILENAMES,
+  XMLConfigLayout,
+  CONFIG_XML_MOD_PROTECTED_FILES,
+} from "./installers.layouts";
+import {
+  instructionsForSameSourceAndDestPaths,
+  instructionsForSourceToDestPairs,
+  moveFromTo,
+  promptToUseProtectedInstructionsOrFail,
+  useFirstMatchingLayoutForInstructions,
+} from "./installers.shared";
+import { InstallerType } from "./installers.types";
+import { promptToFallbackOrFailOnUnresolvableLayout } from "./installer.fallback";
+
+// Recognizers
+
+const matchConfigXML = (filePath: string): boolean =>
+  CONFIG_XML_MOD_EXTENSION === path.extname(filePath);
+
+export const findXMLConfigProtectedFiles = (fileTree: FileTree): string[] =>
+  filesIn(CONFIG_XML_MOD_BASEDIR, matchConfigXML, fileTree).filter((xml) =>
+    CONFIG_XML_MOD_PROTECTED_FILENAMES.includes(path.basename(xml)),
+  );
+
+export const findXMLConfigCanonFiles = (fileTree: FileTree): string[] =>
+  filesIn(CONFIG_XML_MOD_BASEDIR, matchConfigXML, fileTree).filter(
+    (xmlPath) => !CONFIG_XML_MOD_PROTECTED_FILES.includes(xmlPath),
+  );
+
+export const findXMLConfigToplevelFiles = (fileTree: FileTree): string[] =>
+  filesIn(FILETREE_ROOT, matchConfigXML, fileTree).filter((xml) =>
+    CONFIG_XML_MOD_PROTECTED_FILENAMES.includes(path.basename(xml)),
+  );
+
+export const detectXMLConfigProtectedLayout = (fileTree: FileTree): boolean =>
+  findXMLConfigProtectedFiles(fileTree).length > 0;
+
+export const detectXMLConfigCanonLayout = (fileTree: FileTree): boolean =>
+  findXMLConfigCanonFiles(fileTree).length > 0;
+
+export const detectXMLConfigToplevelLayout = (fileTree: FileTree): boolean =>
+  findXMLConfigToplevelFiles(fileTree).length > 0;
+
+// Layouts
+
+const xmlConfigProtectedLayout = (
+  _api: VortexApi,
+  _modName: string,
+  fileTree: FileTree,
+): MaybeInstructions => {
+  const allProtectedXMLConfigFiles = findXMLConfigProtectedFiles(fileTree);
+
+  if (allProtectedXMLConfigFiles.length < 1) {
+    return NoInstructions.NoMatch;
+  }
+
+  const allCanonXMLConfigFiles = findXMLConfigCanonFiles(fileTree);
+
+  const allInstructions = instructionsForSameSourceAndDestPaths([
+    ...allProtectedXMLConfigFiles,
+    ...allCanonXMLConfigFiles,
+  ]);
+
+  return {
+    kind: XMLConfigLayout.Protected,
+    instructions: allInstructions,
+  };
+};
+
+const xmlConfigCanonLayout = (
+  _api: VortexApi,
+  _modName: string,
+  fileTree: FileTree,
+): MaybeInstructions => {
+  const allCanonXMLConfigFiles = findXMLConfigCanonFiles(fileTree);
+
+  if (allCanonXMLConfigFiles.length < 1) {
+    return NoInstructions.NoMatch;
+  }
+
+  return {
+    kind: XMLConfigLayout.Canon,
+    instructions: instructionsForSameSourceAndDestPaths(allCanonXMLConfigFiles),
+  };
+};
+
+const xmlConfigToplevelLayout = (
+  _api: VortexApi,
+  _modName: string,
+  fileTree: FileTree,
+): MaybeInstructions => {
+  const allToplevelXMLConfigFiles = findXMLConfigToplevelFiles(fileTree);
+
+  if (allToplevelXMLConfigFiles.length < 1) {
+    return NoInstructions.NoMatch;
+  }
+
+  const toplevelXMLsToBasedir = allToplevelXMLConfigFiles.map(
+    moveFromTo(FILETREE_ROOT, CONFIG_XML_MOD_BASEDIR),
+  );
+
+  const movingInstructions = instructionsForSourceToDestPairs(toplevelXMLsToBasedir);
+
+  return {
+    kind: XMLConfigLayout.Toplevel,
+    instructions: movingInstructions,
+  };
+};
+
+// testSupport
+
+export const testForXMLConfigMod: VortexWrappedTestSupportedFunc = (
+  _api: VortexApi,
+  _log: VortexLogFunc,
+  _files: string[],
+  fileTree: FileTree,
+): Promise<VortexTestResult> =>
+  Promise.resolve({
+    supported:
+      detectXMLConfigProtectedLayout(fileTree) ||
+      detectXMLConfigCanonLayout(fileTree) ||
+      detectXMLConfigToplevelLayout(fileTree),
+    requiredFiles: [],
+  });
+
+// install
+
+export const installXMLConfigMod: VortexWrappedInstallFunc = async (
+  api: VortexApi,
+  _log: VortexLogFunc,
+  _files: string[],
+  fileTree: FileTree,
+  _destinationPath: string,
+  _progressDelegate: VortexProgressDelegate,
+): Promise<VortexInstallResult> => {
+  const allPossibleXMLConfigLayouts = [
+    xmlConfigProtectedLayout,
+    xmlConfigCanonLayout,
+    xmlConfigToplevelLayout,
+  ];
+  const selectedInstructions = useFirstMatchingLayoutForInstructions(
+    api,
+    undefined,
+    fileTree,
+    allPossibleXMLConfigLayouts,
+  );
+
+  if (
+    selectedInstructions === NoInstructions.NoMatch ||
+    selectedInstructions === InvalidLayout.Conflict
+  ) {
+    return promptToFallbackOrFailOnUnresolvableLayout(
+      api,
+      InstallerType.ConfigXML,
+      fileTree,
+    );
+  }
+
+  const userNeedsToBePrompted =
+    selectedInstructions.kind === XMLConfigLayout.Protected ||
+    selectedInstructions.kind === XMLConfigLayout.Toplevel;
+
+  if (userNeedsToBePrompted) {
+    return promptToUseProtectedInstructionsOrFail(
+      api,
+      InstallerType.ConfigXML,
+      CONFIG_XML_MOD_PROTECTED_FILES,
+      selectedInstructions,
+    );
+  }
+
+  return Promise.resolve({
+    instructions: selectedInstructions.instructions,
+  });
+};
+
+//
+// External use for MultiType etc.
+//
+
+export const detectAllowedXMLConfigLayouts = (fileTree: FileTree): boolean =>
+  detectXMLConfigProtectedLayout(fileTree) || detectXMLConfigCanonLayout(fileTree);
+
+export const xmlConfigAllowedInMultiInstructions = (
+  _api: VortexApi,
+  _fileTree: FileTree,
+): Instructions => ({ kind: NoLayout.Optional, instructions: [] });
+/*
+  const selectedInstructions = xmlConfigCanonLayout(api, undefined, fileTree);
+
+  if (
+    selectedInstructions === NoInstructions.NoMatch ||
+    selectedInstructions === InvalidLayout.Conflict
+  ) {
+    api.log(
+      `debug`,
+      `${InstallerType.ConfigXML}: No valid XML config files found, this is ok`,
+    );
+    return { kind: NoLayout.Optional, instructions: [] };
+  }
+
+  return selectedInstructions;
+  */

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -129,6 +129,12 @@ export const ARCHIVE_XL_CORE_FILES = [
 
 // XML
 
+export const enum XMLConfigLayout {
+  Protected = `.\\r6\\config\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml`,
+  Canon = `.\\r6\\config\\*.xml`,
+  Toplevel = `.\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml`,
+}
+
 export const CONFIG_XML_MOD_BASEDIR = path.join(`r6\\config\\`);
 
 export const CONFIG_XML_MOD_EXTENSION = `.xml`;
@@ -139,6 +145,10 @@ export const CONFIG_XML_MOD_PROTECTED_FILES = [
   path.join(`${CONFIG_XML_MOD_BASEDIR}\\inputUserMappings.xml`),
   path.join(`${CONFIG_XML_MOD_BASEDIR}\\uiInputActions.xml`),
 ];
+
+export const CONFIG_XML_MOD_PROTECTED_FILENAMES = CONFIG_XML_MOD_PROTECTED_FILES.map(
+  (xml) => path.basename(xml),
+);
 
 // JSON
 
@@ -286,6 +296,17 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
     `,
   ],
   [
+    InstallerType.ConfigXML,
+    `
+    - \`${XMLConfigLayout.Protected}\` (Protected)
+    - \`${XMLConfigLayout.Canon}\` (Can be mixed with above)
+    - \`${XMLConfigLayout.Toplevel}\` (Protected, can be moved to canonical)
+
+    Some of the XML config files are protected, because they often contain modifications
+    by the user. There's a prompt before installing into those paths.
+    `,
+  ],
+  [
     InstallerType.TweakXL,
     `
     \`${TweakXLLayout.Canon}\`
@@ -364,6 +385,7 @@ export const enum NoLayout {
 }
 
 export type Layout =
+  | XMLConfigLayout
   | AsiLayout
   | CetLayout
   | RedscriptLayout

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -129,7 +129,7 @@ export const ARCHIVE_XL_CORE_FILES = [
 
 // XML
 
-export const enum XMLConfigLayout {
+export const enum ConfigXmlLayout {
   Protected = `.\\r6\\config\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml`,
   Canon = `.\\r6\\config\\*.xml`,
   Toplevel = `.\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml`,
@@ -296,11 +296,11 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
     `,
   ],
   [
-    InstallerType.ConfigXML,
+    InstallerType.ConfigXml,
     `
-    - \`${XMLConfigLayout.Protected}\` (Protected)
-    - \`${XMLConfigLayout.Canon}\` (Can be mixed with above)
-    - \`${XMLConfigLayout.Toplevel}\` (Protected, can be moved to canonical)
+    - \`${ConfigXmlLayout.Protected}\` (Protected)
+    - \`${ConfigXmlLayout.Canon}\` (Can be mixed with above)
+    - \`${ConfigXmlLayout.Toplevel}\` (Protected, can be moved to canonical)
 
     Some of the XML config files are protected, because they often contain modifications
     by the user. There's a prompt before installing into those paths.
@@ -385,7 +385,7 @@ export const enum NoLayout {
 }
 
 export type Layout =
-  | XMLConfigLayout
+  | ConfigXmlLayout
   | AsiLayout
   | CetLayout
   | RedscriptLayout
@@ -400,8 +400,13 @@ export const enum NoInstructions {
   NoMatch = "attempted layout didn't match",
 }
 
+// Should really refactor these into NoInstructions
 export const enum InvalidLayout {
   Conflict = "can't determine what the intended layout is, conflicting files",
+}
+
+export const enum NotAllowed {
+  CanceledByUser = `user didn't permit using these instructions when prompted`,
 }
 
 export type Instructions = {
@@ -410,6 +415,7 @@ export type Instructions = {
 };
 
 export type MaybeInstructions = Instructions | NoInstructions | InvalidLayout;
+export type PromptedMaybeInstructions = Instructions | NotAllowed;
 
 export type LayoutToInstructions = (
   api: VortexApi,

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -130,9 +130,17 @@ export const ARCHIVE_XL_CORE_FILES = [
 // XML
 
 export const enum ConfigXmlLayout {
-  Protected = `.\\r6\\config\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml`,
-  Canon = `.\\r6\\config\\*.xml`,
-  Toplevel = `.\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml`,
+  Protected = `
+              .\\r6\\config\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml
+              | - .\\r6\\config\\*.xml
+              `,
+  Canon = `
+          .\\r6\\config\\*.xml
+          `,
+  Toplevel = `
+            .\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml
+            | - .\\*.xml
+            `,
 }
 
 export const CONFIG_XML_MOD_BASEDIR = path.join(`r6\\config\\`);

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -12,7 +12,7 @@ import { VortexApi, VortexInstruction } from "./vortex-wrapper";
  * | | | |- 📄 *.xl
  * |-📁 bin
  * | |-📁 x64
- * | | |-📄 *.ini -- Reshade mod
+ * | | |-📄 *.ini -- Reshade mods
  * | | |-📁 reshade-shaders
  * | | |-📁 plugins
  * | | | |- 📄 *.asi
@@ -26,21 +26,30 @@ import { VortexApi, VortexInstruction } from "./vortex-wrapper";
  * | | |-📄 giweights.json
  * | | |-📁 platform
  * | | | |-📁 pc
- * | | | | |-📄 *.ini -- Typically loose files, no subdirs
+ * | | | | |-📄 *.ini
  * |-📁 r6
  * | |-📁 config
+ * | | |-📄 bumperSettings.json
+ * | | |-📄 inputContexts.xml
+ * | | |-📄 inputDeadzones.xml
+ * | | |-📄 inputUserMappings.xml
+ * | | |-📄 uiInputActions.xml
+ * | | |-📄 *.xml
  * | | |-📁 settings
  * | | | |-📄 options.json
  * | | | |-📁 platform
  * | | | | |-📁 pc
  * | | | | | |-📄 options.json
- * | | |-📄 bumperSettings.json
- * | | |-📄 *.xml (68.2 kB)
  * | |-📁 scripts
  * | | |-📁 SomeMod
  * | | | |-📄 *.reds
+ * | |-📁 tweaks
+ * | | |-📄 *.yaml
+ * | | |-📁 SomeMod
+ * | | | |-📄 *.yaml
  * |-📁 red4ext
  * | |-📁 plugins
+ * | | |-📄 *.dll
  * | | |-📁 SomeMod
  * | | | |-📄 *.dll
  */

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -123,6 +123,55 @@ export const ARCHIVE_XL_CORE_FILES = [
   path.join(`red4ext\\plugins\\ArchiveXL\\ArchiveXL.dll`),
 ];
 
+//
+// Config mods of all sorts
+//
+
+// XML
+
+export const CONFIG_XML_MOD_BASEDIR = path.join(`r6\\config\\`);
+
+export const CONFIG_XML_MOD_EXTENSION = `.xml`;
+
+export const CONFIG_XML_MOD_PROTECTED_FILES = [
+  path.join(`${CONFIG_XML_MOD_BASEDIR}\\inputContexts.xml`),
+  path.join(`${CONFIG_XML_MOD_BASEDIR}\\inputDeadzones.xml`),
+  path.join(`${CONFIG_XML_MOD_BASEDIR}\\inputUserMappings.xml`),
+  path.join(`${CONFIG_XML_MOD_BASEDIR}\\uiInputActions.xml`),
+];
+
+// JSON
+
+export const CONFIG_JSON_MOD_EXTENSION = ".json";
+
+export const CONFIG_JSON_MOD_BASEDIR_SETTINGS = path.join(`r6\\config\\settings\\`);
+export const CONFIG_JSON_MOD_BASEDIR_PLATFORM = path.join(
+  `r6\\config\\settings\\platform\\pc\\`,
+);
+
+export const CONFIG_JSON_MOD_KNOWN_FILES = {
+  "giweights.json": path.join("engine", "config", "giweights.json"),
+  "bumpersSettings.json": path.join("r6", "config", "bumpersSettings.json"),
+};
+
+export const CONFIG_JSON_MOD_PROTECTED_FILES = [
+  ...Object.values(CONFIG_JSON_MOD_KNOWN_FILES),
+  path.join(`${CONFIG_JSON_MOD_BASEDIR_SETTINGS}\\options.json`),
+  path.join(`${CONFIG_JSON_MOD_BASEDIR_PLATFORM}\\options.json`),
+];
+
+// INI (these are generally non-overriding)
+
+export const CONFIG_INI_MOD_BASEDIR = path.join("engine", "config", "platform", "pc");
+export const CONFIG_INI_MOD_EXTENSION = ".ini";
+
+export const CONFIG_RESHADE_MOD_BASEDIR = path.join("bin", "x64");
+export const CONFIG_RESHADE_MOD_SHADER_DIRNAME = "reshade-shaders";
+export const CONFIG_RESHADE_MOD_SHADER_BASEDIR = path.join(
+  CONFIG_RESHADE_MOD_BASEDIR,
+  CONFIG_RESHADE_MOD_SHADER_DIRNAME,
+);
+
 // ASI
 
 export const enum AsiLayout {
@@ -177,19 +226,6 @@ export const RED4EXT_KNOWN_NONOVERRIDABLE_DLLS = [
 ];
 
 export const RED4EXT_KNOWN_NONOVERRIDABLE_DLL_DIRS = [path.join(`bin\\x64\\`)];
-
-export const RESHADE_MOD_PATH = path.join("bin", "x64");
-export const RESHADE_SHADERS_DIR = "reshade-shaders";
-export const RESHADE_SHADERS_PATH = path.join(RESHADE_MOD_PATH, RESHADE_SHADERS_DIR);
-
-export const INI_MOD_PATH = path.join("engine", "config", "platform", "pc");
-export const INI_MOD_EXT = ".ini";
-
-export const JSON_FILE_EXT = ".json";
-export const KNOWN_JSON_FILES = {
-  "giweights.json": path.join("engine", "config", "giweights.json"),
-  "bumpersSettings.json": path.join("r6", "config", "bumpersSettings.json"),
-};
 
 // AMM
 

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -47,6 +47,7 @@ import { testForIniMod, installIniMod } from "./installer.config.ini-reshade";
 import { testForJsonMod, installJsonMod } from "./installer.config.json";
 import { testForRed4ExtMod, installRed4ExtMod } from "./installer.red4ext";
 import { testForRedscriptMod, installRedscriptMod } from "./installer.redscript";
+import { installXMLConfigMod, testForXMLConfigMod } from "./installer.xml";
 
 // Ensure we're using win32 conventions
 const path = win32;
@@ -161,6 +162,12 @@ const installers: Installer[] = [
     install: installMultiTypeMod,
   },
   {
+    type: InstallerType.ConfigXML,
+    id: InstallerType.ConfigXML,
+    testSupported: testForXMLConfigMod,
+    install: installXMLConfigMod,
+  },
+  {
     type: InstallerType.CET,
     id: InstallerType.CET,
     testSupported: testForCetMod,
@@ -200,18 +207,12 @@ const installers: Installer[] = [
   },
   /*
   {
-    type: InstallerType.Config,
-    id: "cp2077-config-mod",
-    testSupported: notSupportedModType,
-    install: notInstallableMod,
-  },
-  {
     type: InstallerType.LUT,
     id: "cp2077-lut-mod",
     testSupported: notSupportedModType,
     install: notInstallableMod,
-  }, */
-
+  },
+  */
   {
     type: InstallerType.Json,
     id: InstallerType.Json,

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -47,7 +47,7 @@ import { testForIniMod, installIniMod } from "./installer.config.ini-reshade";
 import { testForJsonMod, installJsonMod } from "./installer.config.json";
 import { testForRed4ExtMod, installRed4ExtMod } from "./installer.red4ext";
 import { testForRedscriptMod, installRedscriptMod } from "./installer.redscript";
-import { installXMLConfigMod, testForXMLConfigMod } from "./installer.xml";
+import { installConfigXmlMod, testForConfigXmlMod } from "./installer.xml";
 
 // Ensure we're using win32 conventions
 const path = win32;
@@ -162,10 +162,10 @@ const installers: Installer[] = [
     install: installMultiTypeMod,
   },
   {
-    type: InstallerType.ConfigXML,
-    id: InstallerType.ConfigXML,
-    testSupported: testForXMLConfigMod,
-    install: installXMLConfigMod,
+    type: InstallerType.ConfigXml,
+    id: InstallerType.ConfigXml,
+    testSupported: testForConfigXmlMod,
+    install: installConfigXmlMod,
   },
   {
     type: InstallerType.CET,

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -23,7 +23,7 @@ export enum InstallerType {
   TweakDB = `(DEPRECATED - USE TweakXL) TweakDB Mod Installer`,
   TweakXL = `TweakXL Mod Installer`,
   INI = `INI Mod Installer`,
-  Config = `Config Mod Installer`,
+  ConfigXML = `XML Config Mod Installer`,
   Reshade = `Reshade Mod Installer`,
   LUT = `LUT Mod Installer`,
   Json = `JSON Mod Installer`,

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -23,7 +23,7 @@ export enum InstallerType {
   TweakDB = `(DEPRECATED - USE TweakXL) TweakDB Mod Installer`,
   TweakXL = `TweakXL Mod Installer`,
   INI = `INI Mod Installer`,
-  ConfigXML = `XML Config Mod Installer`,
+  ConfigXml = `XML Config Mod Installer`,
   Reshade = `Reshade Mod Installer`,
   LUT = `LUT Mod Installer`,
   Json = `JSON Mod Installer`,

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -1497,10 +1497,10 @@ const ValidExtraArchivesWithType = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-const ConfigXMLMod = new Map<string, ExampleSucceedingMod>(
+const ConfigXmlMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
-    configXMLWithRandomNameInCanonicalBasedirWillInstall: {
-      expectedInstallerType: InstallerType.ConfigXML,
+    configXmlWithRandomNameInCanonicalBasedirWillInstall: {
+      expectedInstallerType: InstallerType.ConfigXml,
       inFiles: [path.join(`${CONFIG_XML_MOD_BASEDIR}\\dunnowhythisishere.xml`)],
       outInstructions: [
         copiedToSamePath(path.join(`${CONFIG_XML_MOD_BASEDIR}\\dunnowhythisishere.xml`)),
@@ -1509,18 +1509,18 @@ const ConfigXMLMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-const ConfigXMLModShouldPromptToInstall = new Map<string, ExamplePromptInstallableMod>([
+const ConfigXmlModShouldPromptToInstall = new Map<string, ExamplePromptInstallableMod>([
   ...CONFIG_XML_MOD_PROTECTED_FILES.map(
     (xml: string): [string, ExamplePromptInstallableMod] => [
       `Protected XML file ${path.basename(xml)} in XML basedir prompts to install`,
       {
-        expectedInstallerType: InstallerType.ConfigXML,
+        expectedInstallerType: InstallerType.ConfigXml,
         inFiles: [path.join(xml)],
         proceedLabel: InstallChoices.Proceed,
         proceedOutInstructions: [copiedToSamePath(xml)],
         cancelLabel: InstallChoices.Cancel,
         cancelErrorMessage: expectedUserCancelProtectedMessageFor(
-          InstallerType.ConfigXML,
+          InstallerType.ConfigXml,
         ),
       },
     ],
@@ -1529,7 +1529,7 @@ const ConfigXMLModShouldPromptToInstall = new Map<string, ExamplePromptInstallab
     (xmlname: string): [string, ExamplePromptInstallableMod] => [
       `Protected XML file ${xmlname} in toplevel prompts to install into XML basedir`,
       {
-        expectedInstallerType: InstallerType.ConfigXML,
+        expectedInstallerType: InstallerType.ConfigXml,
         inFiles: [path.join(xmlname)],
         proceedLabel: InstallChoices.Proceed,
         proceedOutInstructions: [
@@ -1541,7 +1541,7 @@ const ConfigXMLModShouldPromptToInstall = new Map<string, ExamplePromptInstallab
         ],
         cancelLabel: InstallChoices.Cancel,
         cancelErrorMessage: expectedUserCancelProtectedMessageFor(
-          InstallerType.ConfigXML,
+          InstallerType.ConfigXml,
         ),
       },
     ],
@@ -1549,7 +1549,7 @@ const ConfigXMLModShouldPromptToInstall = new Map<string, ExamplePromptInstallab
   [
     `Config XML files when there's a combination of protected and non-protected canonical prompts to install`,
     {
-      expectedInstallerType: InstallerType.ConfigXML,
+      expectedInstallerType: InstallerType.ConfigXml,
       inFiles: [
         CONFIG_XML_MOD_PROTECTED_FILES[0],
         path.join(`${CONFIG_XML_MOD_BASEDIR}\\weeblewobble.xml`),
@@ -1560,13 +1560,13 @@ const ConfigXMLModShouldPromptToInstall = new Map<string, ExamplePromptInstallab
         copiedToSamePath(`${CONFIG_XML_MOD_BASEDIR}\\weeblewobble.xml`),
       ],
       cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelProtectedMessageFor(InstallerType.ConfigXML),
+      cancelErrorMessage: expectedUserCancelProtectedMessageFor(InstallerType.ConfigXml),
     },
   ],
   [
     `Config XML files with random XML file in toplevel prompts to install via Fallback`,
     {
-      expectedInstallerType: InstallerType.ConfigXML,
+      expectedInstallerType: InstallerType.ConfigXml,
       inFiles: [path.join(`myfancy.xml`)],
       proceedLabel: InstallChoices.Proceed,
       proceedOutInstructions: [copiedToSamePath(path.join(`myfancy.xml`))],
@@ -2302,7 +2302,7 @@ export const AllExpectedSuccesses = new Map<string, ExampleModCategory>(
     CetMod,
     RedscriptMod,
     Red4ExtMod,
-    ConfigXMLMod,
+    ConfigXmlMod,
     JsonMod,
     IniMod,
     ArchiveOnly: ArchiveMod,
@@ -2333,7 +2333,7 @@ export const AllExpectedInstallPromptables = new Map<
     TweakXLModShouldPromptForInstall,
     ArchiveOnlyModShouldPromptForInstall,
     FallbackForNonMatchedAndInvalidShouldPromptForInstall,
-    ConfigXMLModShouldPromptToInstall,
+    ConfigXmlModShouldPromptToInstall,
     CetModShouldPromptForInstall,
   }),
 );

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -11,9 +11,9 @@ import {
   AMM_MOD_PREFIX,
   ARCHIVE_MOD_CANONICAL_PREFIX,
   ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX,
-  INI_MOD_PATH,
-  RESHADE_MOD_PATH,
-  RESHADE_SHADERS_PATH,
+  CONFIG_INI_MOD_BASEDIR,
+  CONFIG_RESHADE_MOD_BASEDIR,
+  CONFIG_RESHADE_MOD_SHADER_BASEDIR,
   ASI_MOD_PATH,
   RED4EXT_KNOWN_NONOVERRIDABLE_DLL_DIRS,
   RED4EXT_KNOWN_NONOVERRIDABLE_DLLS,
@@ -1600,7 +1600,7 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
         {
           type: "copy",
           source: path.normalize("myawesomeconfig.ini"),
-          destination: path.normalize(`${INI_MOD_PATH}/myawesomeconfig.ini`),
+          destination: path.normalize(`${CONFIG_INI_MOD_BASEDIR}/myawesomeconfig.ini`),
         },
       ],
     },
@@ -1611,12 +1611,12 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
         {
           type: "copy",
           source: path.normalize("myawesomeconfig.ini"),
-          destination: path.normalize(`${INI_MOD_PATH}/myawesomeconfig.ini`),
+          destination: path.normalize(`${CONFIG_INI_MOD_BASEDIR}/myawesomeconfig.ini`),
         },
         {
           type: "copy",
           source: path.normalize("serious.ini"),
-          destination: path.normalize(`${INI_MOD_PATH}/serious.ini`),
+          destination: path.normalize(`${CONFIG_INI_MOD_BASEDIR}/serious.ini`),
         },
       ],
     },
@@ -1627,7 +1627,7 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
         {
           type: "copy",
           source: "superreshade.ini",
-          destination: path.normalize(`${RESHADE_MOD_PATH}/superreshade.ini`),
+          destination: path.normalize(`${CONFIG_RESHADE_MOD_BASEDIR}/superreshade.ini`),
         },
       ],
     },
@@ -1638,7 +1638,7 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
         {
           type: "copy",
           source: path.normalize("fold1/myawesomeconfig.ini"),
-          destination: path.normalize(`${INI_MOD_PATH}/myawesomeconfig.ini`),
+          destination: path.normalize(`${CONFIG_INI_MOD_BASEDIR}/myawesomeconfig.ini`),
         },
       ],
     },
@@ -1656,17 +1656,21 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
         {
           type: "copy",
           source: "superreshade.ini",
-          destination: path.normalize(`${RESHADE_MOD_PATH}/superreshade.ini`),
+          destination: path.normalize(`${CONFIG_RESHADE_MOD_BASEDIR}/superreshade.ini`),
         },
         {
           type: "copy",
           source: path.normalize("reshade-shaders/Shaders/fancy.fx"),
-          destination: path.normalize(`${RESHADE_SHADERS_PATH}/Shaders/fancy.fx`),
+          destination: path.normalize(
+            `${CONFIG_RESHADE_MOD_SHADER_BASEDIR}/Shaders/fancy.fx`,
+          ),
         },
         {
           type: "copy",
           source: path.normalize("reshade-shaders/Textures/lut.png"),
-          destination: path.normalize(`${RESHADE_SHADERS_PATH}/Textures/lut.png`),
+          destination: path.normalize(
+            `${CONFIG_RESHADE_MOD_SHADER_BASEDIR}/Textures/lut.png`,
+          ),
         },
       ],
     },
@@ -1684,17 +1688,21 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
         {
           type: "copy",
           source: path.normalize("fold1/superreshade.ini"),
-          destination: path.normalize(`${RESHADE_MOD_PATH}/superreshade.ini`),
+          destination: path.normalize(`${CONFIG_RESHADE_MOD_BASEDIR}/superreshade.ini`),
         },
         {
           type: "copy",
           source: path.normalize("fold1/reshade-shaders/Shaders/fancy.fx"),
-          destination: path.normalize(`${RESHADE_SHADERS_PATH}/Shaders/fancy.fx`),
+          destination: path.normalize(
+            `${CONFIG_RESHADE_MOD_SHADER_BASEDIR}/Shaders/fancy.fx`,
+          ),
         },
         {
           type: "copy",
           source: path.normalize(`fold1/reshade-shaders/Textures/lut.png`),
-          destination: path.normalize(`${RESHADE_SHADERS_PATH}/Textures/lut.png`),
+          destination: path.normalize(
+            `${CONFIG_RESHADE_MOD_SHADER_BASEDIR}/Textures/lut.png`,
+          ),
         },
       ],
     },

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -2116,21 +2116,6 @@ const ValidTypeCombinations = new Map<string, ExampleSucceedingMod>(
         copiedToSamePath(`${TWEAK_XL_PATH}\\tw\\mytweak.yaml`),
       ],
     },
-    "MultiType: XML + JSON Canonical v1": {
-      expectedInstallerType: InstallerType.MultiType,
-      inFiles: [
-        ...XML_PREFIXES,
-        path.join(`${CONFIG_XML_MOD_BASEDIR}\\inputContext.xml`),
-        path.join(`${CONFIG_XML_MOD_BASEDIR}\\inputUserMappings.xml`),
-        ...pathHierarchyFor(CONFIG_JSON_MOD_PROTECTED_FILES[3]),
-        CONFIG_JSON_MOD_PROTECTED_FILES[3],
-      ],
-      outInstructions: [
-        copiedToSamePath(`${CONFIG_XML_MOD_BASEDIR}\\inputContext.xml`),
-        copiedToSamePath(`${CONFIG_XML_MOD_BASEDIR}\\inputUserMappings.xml`),
-        copiedToSamePath(CONFIG_JSON_MOD_PROTECTED_FILES[3]),
-      ],
-    },
   }),
 );
 

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -117,7 +117,7 @@ const expectedUserCancelProtectedMessageFor = (installerType: InstallerType) =>
 
 const expectedUserCancelProtectedMessageInMultiType = `${InstallerType.MultiType}: user has canceled installation for some part of this mod. Can't proceed safely, canceling entirely.`;
 
-export const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
+const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     coreCetInstall: {
       expectedInstallerType: InstallerType.CoreCET,
@@ -192,7 +192,7 @@ export const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreRedscriptInstall = new Map<string, ExampleSucceedingMod>(
+const CoreRedscriptInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     coreRedscriptInstall: {
       expectedInstallerType: InstallerType.CoreRedscript,
@@ -228,7 +228,7 @@ export const CoreRedscriptInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreTweakXLInstall = new Map<string, ExampleSucceedingMod>(
+const CoreTweakXLInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     coreTweakXLInstallCanon: {
       expectedInstallerType: InstallerType.CoreTweakXL,
@@ -252,10 +252,7 @@ export const CoreTweakXLInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreTweakXLShouldFailOnInstallIfNotExactLayout = new Map<
-  string,
-  ExampleFailingMod
->(
+const CoreTweakXLShouldFailOnInstallIfNotExactLayout = new Map<string, ExampleFailingMod>(
   Object.entries({
     coreTweakXLWithExtraFiles: {
       expectedInstallerType: InstallerType.CoreTweakXL,
@@ -292,7 +289,7 @@ export const CoreTweakXLShouldFailOnInstallIfNotExactLayout = new Map<
   }),
 );
 
-export const TweakXLMod = new Map<string, ExampleSucceedingMod>(
+const TweakXLMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     tweakXLWithFilesInCanonicalDir: {
       expectedInstallerType: InstallerType.TweakXL,
@@ -335,10 +332,7 @@ export const TweakXLMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const TweakXLModShouldPromptForInstall = new Map<
-  string,
-  ExamplePromptInstallableMod
->(
+const TweakXLModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
   Object.entries({
     tweakXLWithFileAtToplevelPromptsToInstallThroughFallback: {
       expectedInstallerType: InstallerType.TweakXL,
@@ -359,7 +353,7 @@ export const TweakXLModShouldPromptForInstall = new Map<
   }),
 );
 
-export const CoreArchiveXLInstall = new Map<string, ExampleSucceedingMod>(
+const CoreArchiveXLInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     coreArchiveXLInstallCanon: {
       expectedInstallerType: InstallerType.CoreArchiveXL,
@@ -374,7 +368,7 @@ export const CoreArchiveXLInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreArchiveXLShouldFailOnInstallIfNotExactLayout = new Map<
+const CoreArchiveXLShouldFailOnInstallIfNotExactLayout = new Map<
   string,
   ExampleFailingMod
 >(
@@ -394,7 +388,7 @@ export const CoreArchiveXLShouldFailOnInstallIfNotExactLayout = new Map<
   }),
 );
 
-export const CoreRed4ExtInstall = new Map<string, ExampleSucceedingMod>(
+const CoreRed4ExtInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     Red4ExtCoreInstallTest: {
       expectedInstallerType: InstallerType.CoreRed4ext,
@@ -430,7 +424,7 @@ export const CoreRed4ExtInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreCsvMergeInstall = new Map<string, ExampleSucceedingMod>(
+const CoreCsvMergeInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     CoreCsvMergeCoreInstallTest: {
       expectedInstallerType: InstallerType.CoreCSVMerge,
@@ -541,7 +535,7 @@ export const CoreCsvMergeInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreWolvenkitCliInstall = new Map<string, ExampleSucceedingMod>(
+const CoreWolvenkitCliInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     CoreWolvenKitCliCoreInstallTest: {
       expectedInstallerType: InstallerType.CoreWolvenKit,
@@ -571,7 +565,7 @@ export const CoreWolvenkitCliInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CoreWolvenKitShouldFailInTest = new Map<string, ExampleFailingMod>(
+const CoreWolvenKitShouldFailInTest = new Map<string, ExampleFailingMod>(
   Object.entries({
     CoreWolvenKitDetectedDesktop: {
       expectedInstallerType: InstallerType.NotSupported,
@@ -584,7 +578,7 @@ export const CoreWolvenKitShouldFailInTest = new Map<string, ExampleFailingMod>(
   }),
 );
 
-export const AsiMod = new Map<string, ExampleSucceedingMod>(
+const AsiMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     asiModWithCet: {
       expectedInstallerType: InstallerType.ASI,
@@ -634,7 +628,7 @@ export const AsiMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CetMod = new Map<string, ExampleSucceedingMod>(
+const CetMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     cetWithOnlyInitCanonical: {
       expectedInstallerType: InstallerType.CET,
@@ -741,7 +735,7 @@ export const CetMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const CetModShouldFail = new Map<string, ExamplePromptInstallableMod>(
+const CetModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
   Object.entries({
     cetModWithIniShouldPromptToInstall: {
       expectedInstallerType: InstallerType.Fallback,
@@ -761,7 +755,7 @@ export const CetModShouldFail = new Map<string, ExamplePromptInstallableMod>(
   }),
 );
 
-export const RedscriptMod = new Map<string, ExampleSucceedingMod>(
+const RedscriptMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     redsWithSingleFileCanonical: {
       expectedInstallerType: InstallerType.Redscript,
@@ -855,10 +849,7 @@ export const RedscriptMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const RedscriptModShouldPromptForInstall = new Map<
-  string,
-  ExamplePromptInstallableMod
->(
+const RedscriptModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
   Object.entries({
     redsWithBasedirAndCanonicalFilesPromptsOnConflictForFallback: {
       expectedInstallerType: InstallerType.Redscript,
@@ -920,7 +911,7 @@ export const RedscriptModShouldPromptForInstall = new Map<
   }),
 );
 
-export const Red4ExtMod = new Map<string, ExampleSucceedingMod>(
+const Red4ExtMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     red4extWithSingleFileCanonical: {
       expectedInstallerType: InstallerType.Red4Ext,
@@ -1107,10 +1098,7 @@ const Red4ExtModShouldFailInTest = new Map<string, ExampleFailingMod>([
   ]),
 ]);
 
-export const Red4ExtModShouldPromptForInstall = new Map<
-  string,
-  ExamplePromptInstallableMod
->(
+const Red4ExtModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
   Object.entries({
     red4extWithMultipleSubdirsPromptsOnConflictForFallback: {
       expectedInstallerType: InstallerType.Red4Ext,
@@ -1162,7 +1150,7 @@ export const Red4ExtModShouldPromptForInstall = new Map<
   }),
 );
 
-export const ArchiveMod = new Map<string, ExampleSucceedingMod>(
+const ArchiveMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     archiveWithSingleFileCanonical: {
       expectedInstallerType: InstallerType.Archive,
@@ -1400,10 +1388,7 @@ export const ArchiveMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const ArchiveOnlyModShouldPromptForInstall = new Map<
-  string,
-  ExamplePromptInstallableMod
->(
+const ArchiveOnlyModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
   Object.entries({
     archiveWithToplevelAndCanonicalFilesPromptsOnConflictForFallback: {
       expectedInstallerType: InstallerType.Archive,
@@ -1431,7 +1416,7 @@ export const ArchiveOnlyModShouldPromptForInstall = new Map<
   }),
 );
 
-export const ValidExtraArchivesWithType = new Map<string, ExampleSucceedingMod>(
+const ValidExtraArchivesWithType = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     cetWithExtraArchiveFilesCanonical: {
       expectedInstallerType: InstallerType.CET,
@@ -1512,7 +1497,7 @@ export const ValidExtraArchivesWithType = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const ConfigXMLMod = new Map<string, ExampleSucceedingMod>(
+const ConfigXMLMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     configXMLWithRandomNameInCanonicalBasedirWillInstall: {
       expectedInstallerType: InstallerType.ConfigXML,
@@ -1524,10 +1509,7 @@ export const ConfigXMLMod = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const ConfigXMLModShouldPromptToInstall = new Map<
-  string,
-  ExamplePromptInstallableMod
->([
+const ConfigXMLModShouldPromptToInstall = new Map<string, ExamplePromptInstallableMod>([
   ...CONFIG_XML_MOD_PROTECTED_FILES.map(
     (xml: string): [string, ExamplePromptInstallableMod] => [
       `Protected XML file ${path.basename(xml)} in XML basedir prompts to install`,
@@ -1594,7 +1576,7 @@ export const ConfigXMLModShouldPromptToInstall = new Map<
   ],
 ]);
 
-export const JsonMod = new Map<string, ExampleSucceedingMod>(
+const JsonMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     jsonWithValidFileInRoot: {
       expectedInstallerType: InstallerType.Json,
@@ -1667,7 +1649,7 @@ export const JsonMod = new Map<string, ExampleSucceedingMod>(
 );
 
 // These errordialogs should be fixed as part o https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/113
-export const JsonModShouldFailInTest = new Map<string, ExampleFailingMod>(
+const JsonModShouldFailInTest = new Map<string, ExampleFailingMod>(
   Object.entries({
     jsonWithInvalidFileInRootFailsInTest: {
       expectedInstallerType: InstallerType.NotSupported,
@@ -1685,7 +1667,7 @@ export const JsonModShouldFailInTest = new Map<string, ExampleFailingMod>(
   }),
 );
 
-export const IniMod = new Map<string, ExampleSucceedingMod>(
+const IniMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     iniWithSingleIniAtRoot: {
       expectedInstallerType: InstallerType.INI,
@@ -1803,7 +1785,7 @@ export const IniMod = new Map<string, ExampleSucceedingMod>(
   }), // object
 );
 
-export const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
+const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
   string,
   ExamplePromptInstallableMod
 >(
@@ -1889,7 +1871,7 @@ export const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
 // The instructions will be grouped in the order that we try
 // to match things, and normally within them.
 //
-export const ValidTypeCombinations = new Map<string, ExampleSucceedingMod>(
+const ValidTypeCombinations = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     cetWithRedsAndArchivesCanonical: {
       expectedInstallerType: InstallerType.MultiType,
@@ -2152,10 +2134,7 @@ export const ValidTypeCombinations = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-export const MultiTypeModShouldPromptForInstall = new Map<
-  string,
-  ExamplePromptInstallableMod
->(
+const MultiTypeModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
   Object.entries({
     "MultiType: XML Config should prompt, w/ CET, Reds, Red4ext, Archive + XL, TweakXL, JSON":
       {
@@ -2269,7 +2248,7 @@ export const MultiTypeModShouldPromptForInstall = new Map<
   }),
 );
 
-export const GiftwrappedModsFixable = new Map<string, ExampleSucceedingMod>(
+const GiftwrappedModsFixable = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     multipleModtypesWrappedAreUnwrappedFixable: {
       expectedInstallerType: InstallerType.MultiType,
@@ -2355,5 +2334,6 @@ export const AllExpectedInstallPromptables = new Map<
     ArchiveOnlyModShouldPromptForInstall,
     FallbackForNonMatchedAndInvalidShouldPromptForInstall,
     ConfigXMLModShouldPromptToInstall,
+    CetModShouldPromptForInstall,
   }),
 );


### PR DESCRIPTION
```ts
export const enum ConfigXmlLayout {
  Protected = `
              .\\r6\\config\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml
              | - .\\r6\\config\\*.xml
              `,
  Canon = `
          .\\r6\\config\\*.xml
          `,
  Toplevel = `
            .\\{inputContexts,inputDeadzones,inputUserMappings,uiInputActions}.xml
            | - .\\*.xml
            `,
}
```

- Implemented ^
- Supported in MultiType

Still need to add support for the common JSON + XML combo.

Of note:

- The concept of 'protected' paths. In this case, the XML files might have changes from other mods or changes the user has made, so we'll warn before installing.
- Messaging for above

Had to restructure how MultiType works to support the possibly failing case. Not entirely happy with how the responsibilities go because we're not _actually_ installing, we're just generating a collection of instructions, but it works.

Closes #99 