### PR TITLE
✨ Core AMM + AMM Mods Support

### DIFF
--- a/src/filetree.ts
+++ b/src/filetree.ts
@@ -149,10 +149,13 @@ export const subdirNamesIn = (dir: string, tree: FileTree): string[] => {
 export const subdirsIn = (dir: string, tree: FileTree): string[] =>
   subdirNamesIn(dir, tree).map((subdir) => nodejsPath.join(dir, subdir));
 
+export const dirInTree = (dir: string, tree: FileTree): boolean =>
+  tree._kt._getNode(stripTrailingSeparator(dir)) !== null;
+
 export const pathInTree = (path: string, tree: FileTree): boolean =>
   // We _could_ just keep track of the paths but since it's possible to mutate..
   path.endsWith(nodejsPath.sep)
-    ? tree._kt._getNode(stripTrailingSeparator(path)) !== null
+    ? dirInTree(path, tree)
     : tree._kt.get(stripTrailingSeparator(nodejsPath.dirname(path))).includes(path);
 
 // Should really implement globbing here, make it much cleaner
@@ -177,15 +180,21 @@ export const filesUnder = (
 
 export const dirWithSomeIn = (
   dir: string,
-  predicate: PathFilter,
+  predicate: PathFilter | Glob,
   tree: FileTree,
-): boolean => tree._kt.get(normalizeDir(dir)).some(predicate);
+): boolean =>
+  predicate !== Glob.Any
+    ? tree._kt.get(normalizeDir(dir)).some(predicate)
+    : tree._kt.get(normalizeDir(dir));
 
 export const dirWithSomeUnder = (
   dir: string,
-  predicate: PathFilter,
+  predicate: PathFilter | Glob,
   tree: FileTree,
-): boolean => tree._kt.getSub(stripTrailingSeparator(dir)).some(predicate);
+): boolean =>
+  predicate !== Glob.Any
+    ? tree._kt.getSub(stripTrailingSeparator(dir)).some(predicate)
+    : tree._kt.getSub(stripTrailingSeparator(dir));
 
 export const findAllFiles = (predicate: PathFilter, tree: FileTree): string[] =>
   findFilesRecursive(predicate, tree._kt.$);

--- a/src/installer.amm.ts
+++ b/src/installer.amm.ts
@@ -1,0 +1,167 @@
+import path from "path";
+import {
+  VortexApi,
+  VortexLogFunc,
+  VortexTestResult,
+  VortexWrappedInstallFunc,
+  VortexWrappedTestSupportedFunc,
+  VortexProgressDelegate,
+  VortexInstallResult,
+} from "./vortex-wrapper";
+import {
+  FileTree,
+  filesUnder,
+  findDirectSubdirsWithSome,
+  Glob,
+  dirInTree,
+  fileCount,
+  subtreeFrom,
+} from "./filetree";
+import {
+  MaybeInstructions,
+  NoInstructions,
+  AmmLayout,
+  InvalidLayout,
+  Instructions,
+  NoLayout,
+  AMM_MOD_CUSTOMS_CANON_DIR,
+  AMM_MOD_USERMOD_CANON_DIR,
+  AMM_BASEDIR_PATH,
+} from "./installers.layouts";
+import { instructionsForSameSourceAndDestPaths } from "./installers.shared";
+import { InstallerType } from "./installers.types";
+import { promptToFallbackOrFailOnUnresolvableLayout } from "./installer.fallback";
+import { extraCanonArchiveInstructions } from "./installer.archive";
+
+const matchAmmLua = (filePath: string): boolean => path.extname(filePath) === `.lua`;
+
+const matchAmmJson = (filePath: string): boolean => path.extname(filePath) === `.json`;
+
+const findAmmCanonCustomsFiles = (fileTree: FileTree): string[] =>
+  findDirectSubdirsWithSome(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree).flatMap(
+    (dir) => filesUnder(dir, Glob.Any, fileTree),
+  );
+
+const findAmmCanonUsermodFiles = (fileTree: FileTree): string[] =>
+  findDirectSubdirsWithSome(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree).flatMap(
+    (dir) => filesUnder(dir, Glob.Any, fileTree),
+  );
+
+const findAmmCanonFiles = (fileTree: FileTree): string[] => [
+  ...findAmmCanonCustomsFiles(fileTree),
+  ...findAmmCanonUsermodFiles(fileTree),
+];
+
+const detectAmmCanonCustomLayouts = (fileTree: FileTree): boolean =>
+  findDirectSubdirsWithSome(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree).length > 0;
+
+const detectAmmCanonUsermodLayouts = (fileTree: FileTree): boolean =>
+  findDirectSubdirsWithSome(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree).length > 0;
+
+const detectAmmCanonLayout = (fileTree: FileTree): boolean =>
+  detectAmmCanonCustomLayouts(fileTree) || detectAmmCanonUsermodLayouts(fileTree);
+
+//
+// Layouts
+//
+
+const ammCanonLayout = (
+  api: VortexApi,
+  _modName: string,
+  fileTree: FileTree,
+): MaybeInstructions => {
+  const allCanonAmmFiles = findAmmCanonFiles(fileTree);
+
+  if (allCanonAmmFiles.length < 1) {
+    return NoInstructions.NoMatch;
+  }
+
+  const totalFilesInAmmBasedir = fileCount(subtreeFrom(AMM_BASEDIR_PATH, fileTree));
+
+  if (allCanonAmmFiles.length !== totalFilesInAmmBasedir) {
+    api.log(`debug`, `${InstallerType.AMM}: unknown files in a canon layout, conflict`);
+    return InvalidLayout.Conflict;
+  }
+
+  const ammCanonInstructions = instructionsForSameSourceAndDestPaths(allCanonAmmFiles);
+
+  const allowedArchiveInstructionsIfAny = extraCanonArchiveInstructions(api, fileTree);
+
+  const allInstructions = [
+    ...ammCanonInstructions,
+    ...allowedArchiveInstructionsIfAny.instructions,
+  ];
+
+  return {
+    kind: AmmLayout.Canon,
+    instructions: allInstructions,
+  };
+};
+
+// testSupport
+
+export const testForAmmMod: VortexWrappedTestSupportedFunc = (
+  _api: VortexApi,
+  _log: VortexLogFunc,
+  _files: string[],
+  fileTree: FileTree,
+): Promise<VortexTestResult> => {
+  const looksLikeCanonAmmMod = dirInTree(`${AMM_BASEDIR_PATH}\\`, fileTree);
+
+  if (looksLikeCanonAmmMod) {
+    return Promise.resolve({
+      supported: true,
+      requiredFiles: [],
+    });
+  }
+
+  return Promise.resolve({ supported: false, requiredFiles: [] });
+};
+
+// install
+
+export const installAmmMod: VortexWrappedInstallFunc = async (
+  api: VortexApi,
+  _log: VortexLogFunc,
+  _files: string[],
+  fileTree: FileTree,
+  _destinationPath: string,
+  _progressDelegate: VortexProgressDelegate,
+): Promise<VortexInstallResult> => {
+  const selectedInstructions = ammCanonLayout(api, undefined, fileTree);
+
+  if (
+    selectedInstructions === NoInstructions.NoMatch ||
+    selectedInstructions === InvalidLayout.Conflict
+  ) {
+    return promptToFallbackOrFailOnUnresolvableLayout(api, InstallerType.AMM, fileTree);
+  }
+
+  return Promise.resolve({
+    instructions: selectedInstructions.instructions,
+  });
+};
+
+//
+// External use for MultiType etc.
+//
+
+export const detectAllowedAmmLayouts = (fileTree: FileTree): boolean =>
+  detectAmmCanonLayout(fileTree);
+
+export const ammAllowedInMultiInstructions = (
+  api: VortexApi,
+  fileTree: FileTree,
+): Instructions => {
+  const selectedInstructions = ammCanonLayout(api, undefined, fileTree);
+
+  if (
+    selectedInstructions === NoInstructions.NoMatch ||
+    selectedInstructions === InvalidLayout.Conflict
+  ) {
+    api.log(`debug`, `${InstallerType.AMM}: No valid extra archives`);
+    return { kind: NoLayout.Optional, instructions: [] };
+  }
+
+  return selectedInstructions;
+};

--- a/src/installer.core.amm.ts
+++ b/src/installer.core.amm.ts
@@ -1,0 +1,78 @@
+import {
+  FileTree,
+  pathInTree,
+  fileCount,
+  sourcePaths,
+  Glob,
+  filesUnder,
+  filesIn,
+} from "./filetree";
+import {
+  AMM_BASEDIR_PATH,
+  AMM_CORE_REQUIRED_PATHS,
+  ARCHIVE_MOD_CANONICAL_PREFIX,
+} from "./installers.layouts";
+import { instructionsForSameSourceAndDestPaths } from "./installers.shared";
+import { InstallerType } from "./installers.types";
+import { showWarningForUnrecoverableStructureError } from "./ui.dialogs";
+import {
+  VortexWrappedTestSupportedFunc,
+  VortexApi,
+  VortexLogFunc,
+  VortexTestResult,
+  VortexWrappedInstallFunc,
+  VortexProgressDelegate,
+} from "./vortex-wrapper";
+
+const findRequiredCoreAmmFiles = (fileTree: FileTree): string[] =>
+  AMM_CORE_REQUIRED_PATHS.filter((requiredFile) => pathInTree(requiredFile, fileTree));
+
+const findAllCoreAmmFiles = (fileTree: FileTree): string[] => [
+  ...filesUnder(AMM_BASEDIR_PATH, Glob.Any, fileTree),
+  ...filesIn(ARCHIVE_MOD_CANONICAL_PREFIX, Glob.Any, fileTree),
+];
+
+const detectCoreAmm = (fileTree: FileTree): boolean =>
+  // We just need to know this looks right, not that it is
+  AMM_CORE_REQUIRED_PATHS.some((requiredFile) => pathInTree(requiredFile, fileTree));
+
+export const testForCoreAmm: VortexWrappedTestSupportedFunc = (
+  _api: VortexApi,
+  _log: VortexLogFunc,
+  _files: string[],
+  fileTree: FileTree,
+): Promise<VortexTestResult> =>
+  Promise.resolve({ supported: detectCoreAmm(fileTree), requiredFiles: [] });
+
+export const installCoreAmm: VortexWrappedInstallFunc = async (
+  api: VortexApi,
+  _log: VortexLogFunc,
+  _files: string[],
+  fileTree: FileTree,
+  _destinationPath: string,
+  _progressDelegate: VortexProgressDelegate,
+) => {
+  const allCoreAmmFiles = findAllCoreAmmFiles(fileTree);
+
+  const missingRequiredCoreAmmFiles =
+    findRequiredCoreAmmFiles(fileTree).length < AMM_CORE_REQUIRED_PATHS.length;
+
+  const hasExtraFiles = allCoreAmmFiles.length > fileCount(fileTree);
+
+  if (missingRequiredCoreAmmFiles || hasExtraFiles) {
+    const errorMessage = `Didn't Find Expected AMM Installation!`;
+    api.log(`error`, `${InstallerType.CoreAmm}: ${errorMessage}`, sourcePaths(fileTree));
+
+    showWarningForUnrecoverableStructureError(
+      api,
+      InstallerType.CoreAmm,
+      errorMessage,
+      sourcePaths(fileTree),
+    );
+
+    return Promise.reject(new Error(errorMessage));
+  }
+
+  const coreAmmInstructions = instructionsForSameSourceAndDestPaths(allCoreAmmFiles);
+  return Promise.resolve({ instructions: coreAmmInstructions });
+};

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -108,6 +108,29 @@ export const enum FallbackLayout {
   Unvalidated = `.\\**\\* - everything in this mod, but nothing has been validated`,
 }
 
+// Archives
+
+export const enum ArchiveLayout {
+  XL = `.\\archive\\pc\\mod\\*.xl, *.archive`, // Required layout per https://github.com/psiberx/cp2077-archive-xl
+  Canon = `.\\archive\\pc\\mod\\*.archive`,
+  Heritage = `.\\archive\\pc\\patch\\*.archive`,
+  Other = `.\\**\\*.archive + [any files + subdirs] (NOTE! These may not work without manual selection)`,
+}
+
+//
+// ArchiveXL Mods
+//
+
+export const ARCHIVE_MOD_FILE_EXTENSION = ".archive";
+export const ARCHIVE_MOD_XL_EXTENSION = `.xl`;
+export const ARCHIVE_MOD_EXTENSIONS = [
+  ARCHIVE_MOD_FILE_EXTENSION,
+  ARCHIVE_MOD_XL_EXTENSION,
+];
+
+export const ARCHIVE_MOD_CANONICAL_PREFIX = path.normalize("archive/pc/mod/");
+export const ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX = path.normalize("archive/pc/patch/");
+
 //
 // Core installers
 //
@@ -276,10 +299,34 @@ export const CET_MOD_CANONICAL_PATH_PREFIX = path.normalize(
 
 export const AMM_BASEDIR_PATH = path.join(
   CET_MOD_CANONICAL_PATH_PREFIX,
-  `AppearanceModMenu`,
+  `AppearanceMenuMod`,
 );
 
 export const AMM_CORE_PLACEHOLDER_FILENAME = `vortex_needs_this.txt`;
+
+export const enum CoreAmmLayout {
+  OnlyValid = `
+              CET:
+
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\init.lua
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\db.sqlite3
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\API.lua
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\Custom Appearances\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\Custom Entities\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\Custom Props\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Themes\\Default.json
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Decor\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Decor\\Backup\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Locations\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Scripts\\[placeholder]
+              - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Themes\\[placeholder]
+
+              Archives:
+
+              - .\\archive\\pc\\mod\\basegame_AMM_Props.archive
+              - .\\archive\\pc\\mod\\basegame_AMM_requirement.archive
+              `,
+}
 
 // Let's keep this very simple? Alternative would be to require
 // a specific layout including the submod dirs, but… that seems
@@ -290,7 +337,21 @@ export const AMM_CORE_PLACEHOLDER_FILENAME = `vortex_needs_this.txt`;
 // it's probably better to just leave that to AMM itself and
 // focus maybe only on protected paths etc.
 //
-export const AMM_CORE_REQUIRED_PATHS = [path.join(`${AMM_BASEDIR_PATH}/init.lua`)];
+export const AMM_CORE_REQUIRED_CET_PATHS = [
+  path.join(`${AMM_BASEDIR_PATH}/init.lua`),
+  path.join(`${AMM_BASEDIR_PATH}/db.sqlite3`),
+  path.join(`${AMM_BASEDIR_PATH}/Collabs/API.lua`),
+];
+
+export const AMM_CORE_REQUIRED_ARCHIVE_PATHS = [
+  path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\basegame_AMM_Props.archive`),
+  path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\basegame_AMM_requirement.archive`),
+];
+
+export const AMM_CORE_REQUIRED_PATHS = [
+  ...AMM_CORE_REQUIRED_CET_PATHS,
+  ...AMM_CORE_REQUIRED_ARCHIVE_PATHS,
+];
 
 export const AMM_MOD_BASEDIR_PATH = AMM_BASEDIR_PATH;
 
@@ -338,28 +399,6 @@ export const RED4EXT_KNOWN_NONOVERRIDABLE_DLL_DIRS = [path.join(`bin\\x64\\`)];
 export const ASI_MOD_EXT = ".asi";
 export const ASI_MOD_PATH = path.join("bin", "x64", "plugins");
 
-// Archives
-
-export const enum ArchiveLayout {
-  XL = `.\\archive\\pc\\mod\\*.xl, *.archive`, // Required layout per https://github.com/psiberx/cp2077-archive-xl
-  Canon = `.\\archive\\pc\\mod\\*.archive`,
-  Heritage = `.\\archive\\pc\\patch\\*.archive`,
-  Other = `.\\**\\*.archive + [any files + subdirs] (NOTE! These may not work without manual selection)`,
-}
-//
-// ArchiveXL Mods
-//
-
-export const ARCHIVE_MOD_FILE_EXTENSION = ".archive";
-export const ARCHIVE_MOD_XL_EXTENSION = `.xl`;
-export const ARCHIVE_MOD_EXTENSIONS = [
-  ARCHIVE_MOD_FILE_EXTENSION,
-  ARCHIVE_MOD_XL_EXTENSION,
-];
-
-export const ARCHIVE_MOD_CANONICAL_PREFIX = path.normalize("archive/pc/mod/");
-export const ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX = path.normalize("archive/pc/patch/");
-
 //
 //
 // Full descriptions
@@ -383,6 +422,14 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
     \`${CoreArchiveXLLayout.OnlyValid}\`
 
     This is the only possible valid layout for ${InstallerType.CoreArchiveXL} that I know of.
+    `,
+  ],
+  [
+    InstallerType.CoreAmm,
+    `
+    ${CoreAmmLayout.OnlyValid}
+
+    This is the only possible valid layout for ${InstallerType.CoreAmm} that I know of.
     `,
   ],
   [

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -477,6 +477,28 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
     `,
   ],
   [
+    InstallerType.AMM,
+    `
+    Any combination of the below canonical layouts (including any canonical Archives)
+
+    ${AmmLayout.Canon}
+    ${ArchiveLayout.Canon}
+
+    Alternatively, any combination of the below toplevel layouts (including toplevel Archives)
+
+    ${ArchiveLayout.Other}
+    `,
+  ],
+  /*
+    ${AmmLayout.CustomAppearancesToplevel}
+    ${AmmLayout.CustomEntitiesToplevel}
+    ${AmmLayout.CustomPropsToplevel}
+    ${AmmLayout.DecorToplevel}
+    ${AmmLayout.LocationsToplevel}
+    ${AmmLayout.ScriptsToplevel}
+    ${AmmLayout.ThemesToplevel}
+    */
+  [
     InstallerType.ConfigJson,
     `
     ${ConfigJsonLayout.Protected}

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -272,6 +272,28 @@ export const CET_MOD_CANONICAL_PATH_PREFIX = path.normalize(
   "bin/x64/plugins/cyber_engine_tweaks/mods",
 );
 
+// AMM is a special case of CET
+
+export const AMM_BASEDIR_PATH = path.join(
+  CET_MOD_CANONICAL_PATH_PREFIX,
+  `AppearanceModMenu`,
+);
+
+export const AMM_CORE_PLACEHOLDER_FILENAME = `vortex_needs_this.txt`;
+
+// Let's keep this very simple? Alternative would be to require
+// a specific layout including the submod dirs, but… that seems
+// not super future proof. It would at least have to be versioned.
+//
+// The upside of speccing more tightly would be that we could
+// maybe control and validate the install better. But I think
+// it's probably better to just leave that to AMM itself and
+// focus maybe only on protected paths etc.
+//
+export const AMM_CORE_REQUIRED_PATHS = [path.join(`${AMM_BASEDIR_PATH}/init.lua`)];
+
+export const AMM_MOD_BASEDIR_PATH = AMM_BASEDIR_PATH;
+
 // Redscript
 
 export const enum RedscriptLayout {
@@ -310,12 +332,6 @@ export const RED4EXT_KNOWN_NONOVERRIDABLE_DLLS = [
 ];
 
 export const RED4EXT_KNOWN_NONOVERRIDABLE_DLL_DIRS = [path.join(`bin\\x64\\`)];
-
-// AMM
-
-export const AMM_MOD_PREFIX = path.normalize(
-  "bin/x64/plugins/cyber_engine_tweaks/mods/AppearanceModMenu/",
-);
 
 // ASI
 

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -355,7 +355,49 @@ export const AMM_CORE_REQUIRED_PATHS = [
 
 export const AMM_MOD_BASEDIR_PATH = AMM_BASEDIR_PATH;
 
+//
+// AMM Mods
+//
+
+export const enum AmmLayout {
+  Canon = `
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\Custom Appearances\\*.lua + [any files or subdirs]
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\Custom Entities\\*.lua + [any files or subdirs]
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\Collabs\\Custom Props\\*.lua + [any files or subdirs]
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Decor\\*.json + [any files or subdirs]
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Locations\\*.json + [any files or subdirs]
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Scripts\\*.json + [any files or subdirs]
+    - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Themes\\*.json + [any files or subdirs]
+    `,
+}
+
+export const AMM_MOD_CUSTOMS_CANON_DIR = path.join(`${AMM_BASEDIR_PATH}\\Collabs`);
+export const AMM_MOD_USERMOD_CANON_DIR = path.join(`${AMM_BASEDIR_PATH}\\User`);
+
+export const AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR = path.join(
+  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Appearances`,
+);
+
+export const AMM_MOD_CUSTOM_ENTITIES_CANON_DIR = path.join(
+  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Entities`,
+);
+
+export const AMM_MOD_CUSTOM_PROPS_CANON_DIR = path.join(
+  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Props`,
+);
+
+export const AMM_MOD_DECOR_CANON_DIR = path.join(`${AMM_MOD_CUSTOMS_CANON_DIR}\\Decor`);
+export const AMM_MOD_LOCATIONS_CANON_DIR = path.join(
+  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Locations`,
+);
+export const AMM_MOD_SCRIPTS_CANON_DIR = path.join(
+  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Scripts`,
+);
+export const AMM_MOD_THEMES_CANON_DIR = path.join(`${AMM_MOD_CUSTOMS_CANON_DIR}\\Themes`);
+
+//
 // Redscript
+//
 
 export const enum RedscriptLayout {
   Canon = `.\\r6\\scripts\\[modname]\\*.reds + [any files + subdirs]`,
@@ -366,7 +408,9 @@ export const enum RedscriptLayout {
 export const REDS_MOD_CANONICAL_EXTENSION = ".reds";
 export const REDS_MOD_CANONICAL_PATH_PREFIX = path.normalize("r6/scripts");
 
+//
 // Red4Ext
+//
 
 export const enum Red4ExtLayout {
   Canon = `.\\red4ext\\plugins\\[modname]\\[*.dll, any files or subdirs]`,
@@ -553,9 +597,11 @@ export const enum NoLayout {
 }
 
 export type Layout =
+  | CoreAmmLayout
   | ConfigJsonLayout
   | ConfigXmlLayout
   | AsiLayout
+  | AmmLayout
   | CetLayout
   | RedscriptLayout
   | Red4ExtLayout

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -53,6 +53,7 @@ import { makeSyntheticName } from "./installers.shared";
 import { extraFilesAllowedInOtherModTypesInstructions } from "./installer.special.extrafiles";
 import { InfoNotification, showInfoNotification } from "./ui.notifications";
 import { installCoreAmm, testForCoreAmm } from "./installer.core.amm";
+import { installAmmMod, testForAmmMod } from "./installer.amm";
 
 // Ensure we're using win32 conventions
 const path = win32;
@@ -171,6 +172,12 @@ const installers: Installer[] = [
     id: InstallerType.MultiType,
     testSupported: testForMultiTypeMod,
     install: installMultiTypeMod,
+  },
+  {
+    type: InstallerType.AMM,
+    id: InstallerType.AMM,
+    testSupported: testForAmmMod,
+    install: installAmmMod,
   },
   {
     type: InstallerType.CET,

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -166,12 +166,6 @@ const installers: Installer[] = [
     install: installMultiTypeMod,
   },
   {
-    type: InstallerType.ConfigXml,
-    id: InstallerType.ConfigXml,
-    testSupported: testForConfigXmlMod,
-    install: installConfigXmlMod,
-  },
-  {
     type: InstallerType.CET,
     id: InstallerType.CET,
     testSupported: testForCetMod,
@@ -222,6 +216,12 @@ const installers: Installer[] = [
     id: InstallerType.ConfigJson,
     testSupported: testForJsonMod,
     install: installJsonMod,
+  },
+  {
+    type: InstallerType.ConfigXml,
+    id: InstallerType.ConfigXml,
+    testSupported: testForConfigXmlMod,
+    install: installConfigXmlMod,
   },
   {
     type: InstallerType.Archive,

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -52,6 +52,7 @@ import { testForRedscriptMod, installRedscriptMod } from "./installer.redscript"
 import { makeSyntheticName } from "./installers.shared";
 import { extraFilesAllowedInOtherModTypesInstructions } from "./installer.special.extrafiles";
 import { InfoNotification, showInfoNotification } from "./ui.notifications";
+import { installCoreAmm, testForCoreAmm } from "./installer.core.amm";
 
 // Ensure we're using win32 conventions
 const path = win32;
@@ -152,6 +153,12 @@ const installers: Installer[] = [
     id: InstallerType.CoreArchiveXL,
     testSupported: testForCoreArchiveXL,
     install: installCoreArchiveXL,
+  },
+  {
+    type: InstallerType.CoreAmm,
+    id: InstallerType.CoreAmm,
+    testSupported: testForCoreAmm,
+    install: installCoreAmm,
   },
   {
     type: InstallerType.ASI,

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -10,6 +10,7 @@ export enum InstallerType {
   SpecialExtraFiles = `(Special) Extra Files Installer`,
   // 'Core' installers for the mod type enablers themselves
   CoreCET = `Core/CET Installer`,
+  CoreAmm = `Core Appearance Menu Mod Installer (special case of CET)`,
   CoreRedscript = `Core/Redscript Installer`,
   CoreRed4ext = `Core/Red4ext Installer`,
   CoreCSVMerge = `Core/CSVMerge Installer`,

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -23,6 +23,7 @@ export enum InstallerType {
   ConfigJson = `JSON Config Mod Installer`,
   ConfigXml = `XML Config Mod Installer`,
   ASI = `ASI Mod Installer`,
+  AMM = `AMM Mod Installer`,
   CET = `CET Mod Installer`,
   Redscript = `Redscript Mod Installer`,
   Red4Ext = `Red4ext Mod Installer`,

--- a/test/unit/filetree.test.ts
+++ b/test/unit/filetree.test.ts
@@ -13,6 +13,7 @@ import {
   pathInTree,
   fileCount,
   prunedTreeFrom,
+  dirInTree,
 } from "../../src/filetree";
 
 const paths = [
@@ -105,6 +106,27 @@ describe("FileTree", () => {
     expect(pathInTree(path.normalize("sub2/nonesuch/"), fileTree)).toBeFalsy();
   });
 
+  test("dirInTree looks for path assuming it's a tree, trailing \\ skipped", () => {
+    const fileTree = fileTreeFromPaths(paths);
+
+    nonEmptyDirPaths.forEach((d) => {
+      expect(dirInTree(d, fileTree)).toBeTruthy();
+    });
+
+    nonEmptyDirPaths
+      .map((d) => path.normalize(`${d}\\`))
+      .forEach((d) => {
+        expect(pathInTree(d, fileTree)).toBeTruthy();
+      });
+
+    emptyDirPaths.forEach((d) => {
+      expect(dirInTree(d, fileTree)).toBeFalsy();
+    });
+
+    expect(dirInTree(path.normalize("foo"), fileTree)).toBeFalsy();
+    expect(dirInTree(path.normalize("topf1"), fileTree)).toBeFalsy();
+    expect(dirInTree(path.normalize("sub2/nonesuch/"), fileTree)).toBeFalsy();
+  });
   test("path lookup", () => {
     const fileTree = fileTreeFromPaths(paths);
 

--- a/test/unit/mods.example.amm.ts
+++ b/test/unit/mods.example.amm.ts
@@ -1,0 +1,315 @@
+import path from "path";
+import {
+  AMM_BASEDIR_PATH,
+  ARCHIVE_MOD_CANONICAL_PREFIX,
+} from "../../src/installers.layouts";
+import { InstallerType } from "../../src/installers.types";
+import { InstallChoices } from "../../src/ui.dialogs";
+import {
+  ExamplesForType,
+  ExampleSucceedingMod,
+  ExampleFailingMod,
+  ExamplePromptInstallableMod,
+  pathHierarchyFor,
+  copiedToSamePath,
+  ARCHIVE_PREFIXES,
+  mergeOrFailOnConflict,
+  expectedUserCancelMessageFor,
+} from "./utils.helper";
+
+const AMM_BASE_PREFIXES = pathHierarchyFor(AMM_BASEDIR_PATH);
+
+const AmmModCanonicalCollabsInstallSucceeds = new Map<string, ExampleSucceedingMod>([
+  [
+    `custom appearance lua in canonical location`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
+      ],
+    },
+  ],
+  [
+    `custom entity lua in canonical location`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+      ],
+    },
+  ],
+  [
+    `custom prop lua in canonical location`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+      ],
+    },
+  ],
+  [
+    `custom combinations in canonical location`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+      ],
+    },
+  ],
+  [
+    `customs including extra archives in canonical location`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+    },
+  ],
+]);
+
+const AmmModCanonicalUserStuffModsInstallSucceeds = new Map<string, ExampleSucceedingMod>(
+  [
+    [
+      `decor json in canonical location`,
+      {
+        expectedInstallerType: InstallerType.AMM,
+        inFiles: [
+          ...AMM_BASE_PREFIXES,
+          path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        ],
+        outInstructions: [
+          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        ],
+      },
+    ],
+    [
+      `location json in canonical location`,
+      {
+        expectedInstallerType: InstallerType.AMM,
+        inFiles: [
+          ...AMM_BASE_PREFIXES,
+          path.join(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
+        ],
+        outInstructions: [
+          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
+        ],
+      },
+    ],
+    [
+      `script json in canonical location`,
+      {
+        expectedInstallerType: InstallerType.AMM,
+        inFiles: [
+          ...AMM_BASE_PREFIXES,
+          path.join(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
+        ],
+        outInstructions: [
+          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
+        ],
+      },
+    ],
+    [
+      `theme json in canonical location`,
+      {
+        expectedInstallerType: InstallerType.AMM,
+        inFiles: [
+          ...AMM_BASE_PREFIXES,
+          path.join(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
+        ],
+        outInstructions: [
+          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
+        ],
+      },
+    ],
+    [
+      `user things combined in canonical location`,
+      {
+        expectedInstallerType: InstallerType.AMM,
+        inFiles: [
+          ...AMM_BASE_PREFIXES,
+          path.join(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
+          path.join(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
+        ],
+        outInstructions: [
+          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
+          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
+        ],
+      },
+    ],
+  ],
+);
+
+const AmmModCanonicalCombinationsInstallSucceeds = new Map<string, ExampleSucceedingMod>([
+  [
+    `combining canonicals`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+    },
+  ],
+]);
+
+const AmmModNonConformingLayoutsPromptToInstall = new Map<
+  string,
+  ExamplePromptInstallableMod
+>([
+  [
+    `luas in user dir prompt to install since should be jsons present at least`,
+    {
+      expectedInstallerType: InstallerType.CoreAmm,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.lua`),
+      ],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.lua`),
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
+    },
+  ],
+  [
+    `jsons in collabs dir prompt to install since should be luas present at least`,
+    {
+      expectedInstallerType: InstallerType.CoreAmm,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custdecor.json`),
+      ],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custdecor.json`),
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
+    },
+  ],
+  [
+    `files in AMM basedir only even if possibly supported`,
+    {
+      expectedInstallerType: InstallerType.CoreAmm,
+      inFiles: [...AMM_BASE_PREFIXES, path.join(`${AMM_BASEDIR_PATH}\\noidea.lua`)],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [copiedToSamePath(`${AMM_BASEDIR_PATH}\\noidea.lua`)],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
+    },
+  ],
+  [
+    `files in AMM basedir even if there are other, supported files in correct places`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        path.join(`${AMM_BASEDIR_PATH}\\wtf.md`),
+        path.join(`${AMM_BASEDIR_PATH}\\swhatisaid.lua`),
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\wtf.md`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\swhatisaid.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
+    },
+  ],
+]);
+
+/*
+const AmmModToplevelsMatchingSchemaInstallSucceeds = new Map<
+  string,
+  ExampleSucceedingMod
+>([
+  [
+    `customs and user stuffs identified in canonical location for type (plus archives)`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
+        path.join(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
+        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
+
+        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      ],
+    },
+  ],
+]);
+*/
+
+const examples: ExamplesForType = {
+  AllExpectedSuccesses: mergeOrFailOnConflict(
+    AmmModCanonicalCollabsInstallSucceeds,
+    AmmModCanonicalUserStuffModsInstallSucceeds,
+    AmmModCanonicalCombinationsInstallSucceeds,
+  ),
+  AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
+  AllExpectedPromptInstalls: mergeOrFailOnConflict(
+    AmmModNonConformingLayoutsPromptToInstall,
+  ),
+};
+
+export default examples;

--- a/test/unit/mods.example.core.amm.ts
+++ b/test/unit/mods.example.core.amm.ts
@@ -1,0 +1,91 @@
+import path from "path";
+import {
+  AMM_BASEDIR_PATH,
+  AMM_CORE_PLACEHOLDER_FILENAME,
+  AMM_CORE_REQUIRED_ARCHIVE_PATHS,
+  AMM_CORE_REQUIRED_CET_PATHS,
+  ARCHIVE_MOD_CANONICAL_PREFIX,
+} from "../../src/installers.layouts";
+import { InstallerType } from "../../src/installers.types";
+import {
+  ExamplesForType,
+  ExampleSucceedingMod,
+  ExampleFailingMod,
+  ExamplePromptInstallableMod,
+  pathHierarchyFor,
+  copiedToSamePath,
+} from "./utils.helper";
+
+const AMM_BASE_PREFIXES = pathHierarchyFor(AMM_BASEDIR_PATH);
+
+// This isn’t quite exhaustive, but covers all existing dirs at least.
+const AMM_CORE_PATHS = [
+  path.join(`${AMM_BASEDIR_PATH}/credits.lua`),
+  path.join(`${AMM_BASEDIR_PATH}/db.sqlite3`),
+  path.join(`${AMM_BASEDIR_PATH}/init.lua`),
+  path.join(`${AMM_BASEDIR_PATH}/update_notes.lua`),
+  path.join(`${AMM_BASEDIR_PATH}/Collabs/API.lua`),
+  path.join(
+    `${AMM_BASEDIR_PATH}/Collabs/Custom Appearances/${AMM_CORE_PLACEHOLDER_FILENAME}`,
+  ),
+  path.join(
+    `${AMM_BASEDIR_PATH}/Collabs/Custom Entities/${AMM_CORE_PLACEHOLDER_FILENAME}`,
+  ),
+  path.join(`${AMM_BASEDIR_PATH}/Collabs/Custom Props/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/External/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/Themes/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/User/Decor/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/User/Decor/Backup/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/User/Locations/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/User/Scripts/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  path.join(`${AMM_BASEDIR_PATH}/User/Themes/${AMM_CORE_PLACEHOLDER_FILENAME}`),
+  // Also some archives, yay
+  path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\basegame_AMM_Props.archive`),
+  path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\basegame_AMM_requirement.archive`),
+];
+
+const AmmCoreInstallSucceeds = new Map<string, ExampleSucceedingMod>([
+  [
+    `Core AMM installs without prompting when all required paths present`,
+    {
+      expectedInstallerType: InstallerType.CoreAmm,
+      inFiles: [...AMM_BASE_PREFIXES, ...AMM_CORE_PATHS],
+      outInstructions: [...AMM_CORE_PATHS.map((p) => copiedToSamePath(p))],
+    },
+  ],
+]);
+
+const AmmCoreFailsDirectly = new Map<string, ExampleFailingMod>([
+  [
+    `Core AMM cancels installation without prompting when all required CET side paths are not present`,
+    {
+      expectedInstallerType: InstallerType.CoreAmm,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        ...AMM_CORE_PATHS.filter((p) => p === AMM_CORE_REQUIRED_CET_PATHS[0]),
+      ],
+      failure: `Didn't Find Expected AMM Installation!`,
+      errorDialogTitle: `Didn't Find Expected AMM Installation!`,
+    },
+  ],
+  [
+    `Core AMM cancels installation without prompting when all required Archive side paths are not present`,
+    {
+      expectedInstallerType: InstallerType.CoreAmm,
+      inFiles: [
+        ...AMM_BASE_PREFIXES,
+        ...AMM_CORE_PATHS.filter((p) => p === AMM_CORE_REQUIRED_ARCHIVE_PATHS[0]),
+      ],
+      failure: `Didn't Find Expected AMM Installation!`,
+      errorDialogTitle: `Didn't Find Expected AMM Installation!`,
+    },
+  ],
+]);
+
+const examples: ExamplesForType = {
+  AllExpectedSuccesses: AmmCoreInstallSucceeds,
+  AllExpectedDirectFailures: AmmCoreFailsDirectly,
+  AllExpectedPromptInstalls: new Map<string, ExamplePromptInstallableMod>(),
+};
+
+export default examples;

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/first */
 import path from "path";
 import {
   ARCHIVE_GIFTWRAPS,
@@ -1747,6 +1748,7 @@ const GiftwrappedModsFixable = new Map<string, ExampleSucceedingMod>(
 //
 
 import AmmCore from "./mods.example.core.amm";
+import AmmMod from "./mods.example.amm";
 import MultiTypeMod from "./mods.example.multitype";
 import JsonMod from "./mods.example.config.json";
 
@@ -1767,6 +1769,7 @@ export const AllExpectedSuccesses = new Map<string, ExampleModCategory>(
     TweakXLMod,
     CoreArchiveXLInstall,
     AsiMod,
+    AmmModInstallShouldSucceed: AmmMod.AllExpectedSuccesses,
     CetMod,
     RedscriptMod,
     Red4ExtMod,
@@ -1787,6 +1790,7 @@ export const AllExpectedDirectFailures = new Map<string, ExampleFailingModCatego
     MultiTypeModShouldFailDirectly: MultiTypeMod.AllExpectedDirectFailures,
     ConfigJsonModShouldFailDirectly: JsonMod.AllExpectedDirectFailures,
     Red4ExtModShouldFailInTest,
+    AmmModInstallShouldFailDirectly: AmmMod.AllExpectedDirectFailures,
   }),
 );
 
@@ -1799,6 +1803,7 @@ export const AllExpectedInstallPromptables = new Map<
     MultiTypeModShouldPromptForInstall: MultiTypeMod.AllExpectedPromptInstalls,
     ConfigXmlModShouldPromptToInstall,
     ConfigJsonModShouldPromptForInstall: JsonMod.AllExpectedPromptInstalls,
+    AmmModShouldPromptForInstall: AmmMod.AllExpectedPromptInstalls,
     CetModShouldPromptForInstall,
     RedscriptModShouldPromptForInstall,
     Red4ExtModShouldPromptForInstall,

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -39,7 +39,6 @@ import {
 
 import {
   CET_MOD_CANONICAL_PATH_PREFIX,
-  AMM_MOD_PREFIX,
   ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX,
   CONFIG_INI_MOD_BASEDIR,
   CONFIG_RESHADE_MOD_BASEDIR,
@@ -52,11 +51,6 @@ import {
 } from "../../src/installers.layouts";
 import { InstallChoices } from "../../src/ui.dialogs";
 import { InstallerType } from "../../src/installers.types";
-
-import MultiTypeMod from "./mods.example.multitype";
-import JsonMod from "./mods.example.config.json";
-
-import ExtraFiles from "./mods.example.special.extrafiles";
 
 const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
@@ -1705,31 +1699,6 @@ const FallbackForNonMatchedAndInvalidShouldPromptForInstall = new Map<
       cancelLabel: InstallChoices.Cancel,
       cancelErrorMessage: expectedUserCancelMessageForHittingFallback,
     },
-    // Fallback for mods containing JSON that will later be handled by AMM
-    validAmmModUsingFallback: {
-      expectedInstallerType: InstallerType.Fallback,
-      inFiles: [
-        ...ARCHIVE_PREFIXES,
-        path.join(ARCHIVE_PREFIX, "proximas_propshop_v4.archive"),
-        ...pathHierarchyFor(AMM_MOD_PREFIX),
-        path.join(AMM_MOD_PREFIX, "Collabs/"),
-        path.join(AMM_MOD_PREFIX, "Collabs/Custom Props/"),
-        path.join(AMM_MOD_PREFIX, "Collabs/Custom Props/proximas_propshop_v4.lua"),
-        path.join(AMM_MOD_PREFIX, "User/"),
-        path.join(AMM_MOD_PREFIX, "User/Decor/"),
-        path.join(AMM_MOD_PREFIX, "User/Decor/Cyber Noir Flat.json"),
-      ],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        copiedToSamePath(path.join(ARCHIVE_PREFIX, "proximas_propshop_v4.archive")),
-        copiedToSamePath(
-          path.join(AMM_MOD_PREFIX, "Collabs/Custom Props/proximas_propshop_v4.lua"),
-        ),
-        copiedToSamePath(path.join(AMM_MOD_PREFIX, "User/Decor/Cyber Noir Flat.json")),
-      ],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageForHittingFallback,
-    },
   }), // object
 );
 
@@ -1773,8 +1742,19 @@ const GiftwrappedModsFixable = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
+//
+// And then the already-split-up types
+//
+
+import AmmCore from "./mods.example.core.amm";
+import MultiTypeMod from "./mods.example.multitype";
+import JsonMod from "./mods.example.config.json";
+
+import ExtraFiles from "./mods.example.special.extrafiles";
+
 export const AllExpectedSuccesses = new Map<string, ExampleModCategory>(
   Object.entries({
+    CoreAmmInstallShouldSucceed: AmmCore.AllExpectedSuccesses,
     CoreCetInstall,
     CoreRedscriptInstall,
     CoreRed4ExtInstall,
@@ -1800,6 +1780,7 @@ export const AllExpectedSuccesses = new Map<string, ExampleModCategory>(
 
 export const AllExpectedDirectFailures = new Map<string, ExampleFailingModCategory>(
   Object.entries({
+    CoreAmmInstallShouldFailDirectly: AmmCore.AllExpectedDirectFailures,
     CoreWolvenKitShouldFailInTest,
     CoreTweakXLShouldFailOnInstallIfNotExactLayout,
     CoreArchiveXLShouldFailOnInstallIfNotExactLayout,
@@ -1814,6 +1795,7 @@ export const AllExpectedInstallPromptables = new Map<
   ExamplePromptInstallableModCategory
 >(
   Object.entries({
+    CoreAmmModShouldPromptForInstall: AmmCore.AllExpectedPromptInstalls,
     MultiTypeModShouldPromptForInstall: MultiTypeMod.AllExpectedPromptInstalls,
     ConfigXmlModShouldPromptToInstall,
     ConfigJsonModShouldPromptForInstall: JsonMod.AllExpectedPromptInstalls,


### PR DESCRIPTION
- Validate a minimal set of files to constitute a valid core AMM installation. There might not be a strict need for this, but it does allow us to treat it as a distinct entity, and possibly e.g. protect files, ensure proper cleanup etc.

- Support the following kinds of AMM mods in canon location

  - [x] Custom Appearances
  - [x] Custom Entities
  - [x] Custom Props
  - [x] Decors
  - [x] Locations
  - [x] Scripts
  - [x] Themes 

Toplevel support left out, follow-up in #152 

Closes #56  (add more tickets for more specific problems)
Closes #141 