### PR TITLE
✨ AMM Toplevel Mod Support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,12 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Node",
+      "port": 9229
+    },
+    {
       "name": "Debug Jest Tests",
       "type": "node",
       "request": "launch",
@@ -15,12 +21,6 @@
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
-    },
-    {
-      "type": "node",
-      "request": "attach",
-      "name": "Attach to Node",
       "port": 9229
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
+        "fp-ts": "^2.12.1",
         "key-tree": "^1.0.3",
         "patch-package": "^6.4.7"
       },
@@ -5574,6 +5575,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fp-ts": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
+      "integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw=="
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
@@ -18005,6 +18011,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "fp-ts": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
+      "integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
+    "fp-ts": "^2.12.1",
     "key-tree": "^1.0.3",
     "patch-package": "^6.4.7"
   }

--- a/src/installer.amm.ts
+++ b/src/installer.amm.ts
@@ -16,6 +16,7 @@ import {
   dirInTree,
   fileCount,
   subtreeFrom,
+  PathFilter,
 } from "./filetree";
 import {
   MaybeInstructions,
@@ -34,32 +35,31 @@ import { promptToFallbackOrFailOnUnresolvableLayout } from "./installer.fallback
 import { extraCanonArchiveInstructions } from "./installer.archive";
 
 const matchAmmLua = (filePath: string): boolean => path.extname(filePath) === `.lua`;
-
 const matchAmmJson = (filePath: string): boolean => path.extname(filePath) === `.json`;
 
-const findAmmCanonCustomsFiles = (fileTree: FileTree): string[] =>
-  findDirectSubdirsWithSome(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree).flatMap(
-    (dir) => filesUnder(dir, Glob.Any, fileTree),
-  );
-
-const findAmmCanonUsermodFiles = (fileTree: FileTree): string[] =>
-  findDirectSubdirsWithSome(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree).flatMap(
-    (dir) => filesUnder(dir, Glob.Any, fileTree),
+const findAmmFiles = (
+  ammDir: string,
+  kindMatcher: PathFilter,
+  fileTree: FileTree,
+): string[] =>
+  findDirectSubdirsWithSome(ammDir, kindMatcher, fileTree).flatMap((dir) =>
+    filesUnder(dir, Glob.Any, fileTree),
   );
 
 const findAmmCanonFiles = (fileTree: FileTree): string[] => [
-  ...findAmmCanonCustomsFiles(fileTree),
-  ...findAmmCanonUsermodFiles(fileTree),
+  ...findAmmFiles(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree),
+  ...findAmmFiles(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree),
 ];
 
-const detectAmmCanonCustomLayouts = (fileTree: FileTree): boolean =>
-  findDirectSubdirsWithSome(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree).length > 0;
-
-const detectAmmCanonUsermodLayouts = (fileTree: FileTree): boolean =>
-  findDirectSubdirsWithSome(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree).length > 0;
+const detectAmmLayout = (
+  ammDir: string,
+  kindMatcher: PathFilter,
+  fileTree: FileTree,
+): boolean => findDirectSubdirsWithSome(ammDir, kindMatcher, fileTree).length > 0;
 
 const detectAmmCanonLayout = (fileTree: FileTree): boolean =>
-  detectAmmCanonCustomLayouts(fileTree) || detectAmmCanonUsermodLayouts(fileTree);
+  detectAmmLayout(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree) ||
+  detectAmmLayout(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree);
 
 //
 // Layouts

--- a/src/installer.amm.ts
+++ b/src/installer.amm.ts
@@ -1,4 +1,8 @@
 import path from "path";
+import * as A from "fp-ts/Array";
+import { Option, some, none } from "fp-ts/Option";
+import * as T from "fp-ts/Task";
+import { pipe } from "fp-ts/lib/function";
 import {
   VortexApi,
   VortexLogFunc,
@@ -7,6 +11,7 @@ import {
   VortexWrappedTestSupportedFunc,
   VortexProgressDelegate,
   VortexInstallResult,
+  VortexInstruction,
 } from "./vortex-wrapper";
 import {
   FileTree,
@@ -18,21 +23,39 @@ import {
   subtreeFrom,
   PathFilter,
   FILETREE_ROOT,
+  filesIn,
 } from "./filetree";
 import {
   MaybeInstructions,
   NoInstructions,
   AmmLayout,
   InvalidLayout,
-  Instructions,
-  NoLayout,
   AMM_MOD_CUSTOMS_CANON_DIR,
   AMM_MOD_USERMOD_CANON_DIR,
   AMM_BASEDIR_PATH,
   AMM_MOD_CUSTOMS_DIRNAME,
   AMM_MOD_USERMOD_DIRNAME,
+  AMM_MOD_DECOR_CANON_DIR,
+  AMM_MOD_LOCATIONS_CANON_DIR,
+  AMM_MOD_SCRIPTS_CANON_DIR,
+  AMM_MOD_THEMES_CANON_DIR,
+  AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR,
+  AMM_MOD_APPEARANCES_REQUIRED_MATCHES,
+  AMM_MOD_CUSTOM_ENTITIES_CANON_DIR,
+  AMM_MOD_CUSTOM_PROPS_CANON_DIR,
+  AMM_MOD_DECOR_REQUIRED_KEYS,
+  AMM_MOD_ENTITIES_REQUIRED_MATCHES,
+  AMM_MOD_LOCATION_REQUIRED_KEYS,
+  AMM_MOD_PROPS_REQUIRED_MATCHES,
+  AMM_MOD_SCRIPT_REQUIRED_KEYS,
+  AMM_MOD_THEME_REQUIRED_KEYS,
 } from "./installers.layouts";
 import {
+  File,
+  fileFromDisk,
+  FileMove,
+  fileMove,
+  fileToInstruction,
   instructionsForSameSourceAndDestPaths,
   instructionsForSourceToDestPairs,
   moveFromTo,
@@ -47,6 +70,8 @@ import {
 
 const matchAmmLua = (filePath: string): boolean => path.extname(filePath) === `.lua`;
 const matchAmmJson = (filePath: string): boolean => path.extname(filePath) === `.json`;
+const matchAmmExt = (filePath: string): boolean =>
+  [".json", ".lua"].includes(path.extname(filePath));
 
 const findAmmFiles = (
   ammDir: string,
@@ -73,13 +98,53 @@ const detectAmmLayout = (
   fileTree: FileTree,
 ): boolean => findDirectSubdirsWithSome(ammDir, kindMatcher, fileTree).length > 0;
 
-const detectAmmCanonLayout = (fileTree: FileTree): boolean =>
-  detectAmmLayout(AMM_MOD_CUSTOMS_CANON_DIR, matchAmmLua, fileTree) ||
-  detectAmmLayout(AMM_MOD_USERMOD_CANON_DIR, matchAmmJson, fileTree);
-
 const detectAmmToplevelCanonSubdirLayout = (fileTree: FileTree): boolean =>
   detectAmmLayout(AMM_MOD_CUSTOMS_DIRNAME, matchAmmLua, fileTree) ||
   detectAmmLayout(AMM_MOD_USERMOD_DIRNAME, matchAmmJson, fileTree);
+
+const ammLuaContentToPath: [RegExp[], string][] = [
+  [AMM_MOD_APPEARANCES_REQUIRED_MATCHES, AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR],
+  [AMM_MOD_ENTITIES_REQUIRED_MATCHES, AMM_MOD_CUSTOM_ENTITIES_CANON_DIR],
+  [AMM_MOD_PROPS_REQUIRED_MATCHES, AMM_MOD_CUSTOM_PROPS_CANON_DIR],
+];
+
+const ammJsonContentToPath: [string[], string][] = [
+  [AMM_MOD_DECOR_REQUIRED_KEYS, AMM_MOD_DECOR_CANON_DIR],
+  [AMM_MOD_LOCATION_REQUIRED_KEYS, AMM_MOD_LOCATIONS_CANON_DIR],
+  [AMM_MOD_SCRIPT_REQUIRED_KEYS, AMM_MOD_SCRIPTS_CANON_DIR],
+  [AMM_MOD_THEME_REQUIRED_KEYS, AMM_MOD_THEMES_CANON_DIR],
+];
+
+const canonPrefixedPathByTypeIfActualAmmMod = (file: File): Option<FileMove> => {
+  const kind = path.extname(file.pathOnDisk);
+
+  if (kind === `.json`) {
+    const keysInData = Object.keys(JSON.parse(file.content));
+
+    const jsonKeyMatcher = A.findFirstMap<[string[], string], FileMove>(
+      ([requiredKeys, canonDirForType]) =>
+        keysInData.length >= requiredKeys.length &&
+        requiredKeys.every((key) => keysInData.includes(key))
+          ? some(fileMove(canonDirForType, file))
+          : none,
+    );
+
+    return jsonKeyMatcher(ammJsonContentToPath);
+  }
+
+  if (kind === `.lua`) {
+    const luaContentMatcher = A.findFirstMap<[RegExp[], string], FileMove>(
+      ([requiredMatches, canonDirForType]) =>
+        requiredMatches.every((required) => file.content.match(required))
+          ? some(fileMove(canonDirForType, file))
+          : none,
+    );
+
+    return luaContentMatcher(ammLuaContentToPath);
+  }
+
+  return none;
+};
 
 //
 // Layouts
@@ -146,13 +211,57 @@ const ammToplevelCanonSubdirLayout = (
   };
 };
 
+const ammToplevelLayout = async (
+  api: VortexApi,
+  sourceDirPathForMod: string,
+  _modName: string,
+  fileTree: FileTree,
+): Promise<MaybeInstructions> => {
+  const allToplevelCandidates: File[] = await pipe(
+    filesIn(FILETREE_ROOT, matchAmmExt, fileTree),
+    A.traverse(T.ApplicativePar)((filePath) =>
+      fileFromDisk(path.join(sourceDirPathForMod, filePath), filePath),
+    ),
+  )();
+
+  const toplevelAmmInstructions: VortexInstruction[] = pipe(
+    allToplevelCandidates,
+    A.filterMap(canonPrefixedPathByTypeIfActualAmmMod),
+    A.map(fileToInstruction),
+  );
+
+  if (toplevelAmmInstructions.length < 1) {
+    return NoInstructions.NoMatch;
+  }
+
+  if (toplevelAmmInstructions.length !== allToplevelCandidates.length) {
+    return InvalidLayout.Conflict;
+  }
+
+  const allowedArchiveInstructionsIfAny = extraToplevelArchiveInstructions(api, fileTree);
+
+  const allInstructions = [
+    ...toplevelAmmInstructions,
+    ...allowedArchiveInstructionsIfAny.instructions,
+  ];
+
+  return {
+    kind: AmmLayout.Toplevel,
+    instructions: allInstructions,
+  };
+};
+
 // testSupport
 
-export const testForAmmMod: VortexWrappedTestSupportedFunc = (
-  _api: VortexApi,
+export const testForAmmMod: VortexWrappedTestSupportedFunc = async (
+  api: VortexApi,
   _log: VortexLogFunc,
   _files: string[],
   fileTree: FileTree,
+  _destinationPath: string,
+  sourceDirPathForMod: string,
+  _stagingDirPathForMod: string,
+  _modName: string,
 ): Promise<VortexTestResult> => {
   const looksLikeAmm = dirInTree(AMM_BASEDIR_PATH, fileTree);
 
@@ -165,7 +274,34 @@ export const testForAmmMod: VortexWrappedTestSupportedFunc = (
     });
   }
 
-  return Promise.resolve({ supported: false, requiredFiles: [] });
+  const hasToplevelCandidates = filesIn(FILETREE_ROOT, matchAmmExt, fileTree).length > 0;
+
+  if (!hasToplevelCandidates) {
+    return Promise.resolve({ supported: false, requiredFiles: [] });
+  }
+
+  // Here we actually have to check the contents in testSupport
+  // because there are other possible .lua and .json files that
+  // could appear toplevel. And then we duplicate this in install..
+  const maybeToplevelAmmInstructions = await ammToplevelLayout(
+    api,
+    sourceDirPathForMod,
+    undefined,
+    fileTree,
+  );
+
+  const hasToplevelAmmFiles =
+    maybeToplevelAmmInstructions !== NoInstructions.NoMatch &&
+    maybeToplevelAmmInstructions !== InvalidLayout.Conflict;
+
+  if (hasToplevelAmmFiles) {
+    return {
+      supported: true,
+      requiredFiles: [],
+    };
+  }
+
+  return { supported: false, requiredFiles: [] };
 };
 
 // install
@@ -175,15 +311,21 @@ export const installAmmMod: VortexWrappedInstallFunc = async (
   _log: VortexLogFunc,
   _files: string[],
   fileTree: FileTree,
-  _destinationPath: string,
+  stagingDirPath: string,
   _progressDelegate: VortexProgressDelegate,
 ): Promise<VortexInstallResult> => {
-  const selectedInstructions = useFirstMatchingLayoutForInstructions(
+  const pathBasedMatchInstructions = useFirstMatchingLayoutForInstructions(
     api,
     undefined,
     fileTree,
     [ammCanonLayout, ammToplevelCanonSubdirLayout],
   );
+
+  const selectedInstructions =
+    pathBasedMatchInstructions === NoInstructions.NoMatch ||
+    pathBasedMatchInstructions === InvalidLayout.Conflict
+      ? await ammToplevelLayout(api, stagingDirPath, undefined, fileTree)
+      : pathBasedMatchInstructions;
 
   if (
     selectedInstructions === NoInstructions.NoMatch ||
@@ -197,29 +339,7 @@ export const installAmmMod: VortexWrappedInstallFunc = async (
   });
 };
 
-//
-// External use for MultiType etc.
-//
-
-export const detectAllowedAmmLayouts = (fileTree: FileTree): boolean =>
-  detectAmmCanonLayout(fileTree);
-
-export const ammAllowedInMultiInstructions = (
-  api: VortexApi,
-  fileTree: FileTree,
-): Instructions => {
-  const selectedInstructions = ammCanonLayout(api, undefined, fileTree);
-
-  if (
-    selectedInstructions === NoInstructions.NoMatch ||
-    selectedInstructions === InvalidLayout.Conflict
-  ) {
-    api.log(
-      `debug`,
-      `${InstallerType.AMM}: No valid extra AMM layout found (this is ok)`,
-    );
-    return { kind: NoLayout.Optional, instructions: [] };
-  }
-
-  return selectedInstructions;
-};
+// For right now, at least, we'll let CET handle AMM mods in MultiType.
+// There shouldn't be a pressing reason to have to distinguish them there
+// since the layout will be canonical and any special handling applies
+// to the entire mod anyway.

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -117,6 +117,12 @@ export const enum ArchiveLayout {
   Other = `.\\**\\*.archive + [any files + subdirs] (NOTE! These may not work without manual selection)`,
 }
 
+export const enum ExtraArchiveLayout {
+  Toplevel = `
+    .\\*.xl, *.archive
+  `,
+}
+
 //
 // ArchiveXL Mods
 //
@@ -631,6 +637,7 @@ export type Layout =
   | ArchiveLayout
   | FallbackLayout
   | GiftwrapLayout
+  | ExtraArchiveLayout
   | ExtraFilesLayout
   | NoLayout;
 

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -408,22 +408,52 @@ export const AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR = path.join(
   `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Appearances`,
 );
 
+export const AMM_MOD_APPEARANCES_REQUIRED_MATCHES = [
+  /modder\s*=/,
+  /unique_identifier\s*=/,
+  /entity_id\s*=/,
+  /appearances\s*=/,
+];
+
 export const AMM_MOD_CUSTOM_ENTITIES_CANON_DIR = path.join(
   `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Entities`,
 );
+
+export const AMM_MOD_ENTITIES_REQUIRED_MATCHES = [
+  /modder\s*=/,
+  /unique_identifier\s*=/,
+  /entity_info\s*=/,
+];
 
 export const AMM_MOD_CUSTOM_PROPS_CANON_DIR = path.join(
   `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Props`,
 );
 
-export const AMM_MOD_DECOR_CANON_DIR = path.join(`${AMM_MOD_CUSTOMS_CANON_DIR}\\Decor`);
+export const AMM_MOD_PROPS_REQUIRED_MATCHES = [
+  /modder\s*=/,
+  /unique_identifier\s*=/,
+  /props\s*=/,
+];
+
+export const AMM_MOD_DECOR_CANON_DIR = path.join(`${AMM_MOD_USERMOD_CANON_DIR}\\Decor`);
+
+export const AMM_MOD_DECOR_REQUIRED_KEYS = [`name`, `props`, `lights`];
+
 export const AMM_MOD_LOCATIONS_CANON_DIR = path.join(
-  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Locations`,
+  `${AMM_MOD_USERMOD_CANON_DIR}\\Locations`,
 );
+
+export const AMM_MOD_LOCATION_REQUIRED_KEYS = [`x`, `y`, `z`];
+
 export const AMM_MOD_SCRIPTS_CANON_DIR = path.join(
-  `${AMM_MOD_CUSTOMS_CANON_DIR}\\Scripts`,
+  `${AMM_MOD_USERMOD_CANON_DIR}\\Scripts`,
 );
-export const AMM_MOD_THEMES_CANON_DIR = path.join(`${AMM_MOD_CUSTOMS_CANON_DIR}\\Themes`);
+
+export const AMM_MOD_SCRIPT_REQUIRED_KEYS = [`title`, `actors`];
+
+export const AMM_MOD_THEMES_CANON_DIR = path.join(`${AMM_MOD_USERMOD_CANON_DIR}\\Themes`);
+
+export const AMM_MOD_THEME_REQUIRED_KEYS = [`Text`, `Border`];
 
 //
 // Redscript

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -546,18 +546,11 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
 
     Alternatively, any combination of the below toplevel layouts (including toplevel Archives)
 
+    ${AmmLayout.ToplevelCanonSubdir}
+    ${AmmLayout.Toplevel}
     ${ArchiveLayout.Other}
     `,
   ],
-  /*
-    ${AmmLayout.CustomAppearancesToplevel}
-    ${AmmLayout.CustomEntitiesToplevel}
-    ${AmmLayout.CustomPropsToplevel}
-    ${AmmLayout.DecorToplevel}
-    ${AmmLayout.LocationsToplevel}
-    ${AmmLayout.ScriptsToplevel}
-    ${AmmLayout.ThemesToplevel}
-    */
   [
     InstallerType.ConfigJson,
     `

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -375,10 +375,34 @@ export const enum AmmLayout {
     - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Scripts\\*.json + [any files or subdirs]
     - .\\bin\\x64\\plugins\\cyber_engine_tweaks\\mods\\AppearanceMenuMod\\User\\Themes\\*.json + [any files or subdirs]
     `,
+  ToplevelCanonSubdir = `
+    - .\\Collabs\\Custom Appearances\\*.lua + [any files or subdirs]
+    - .\\Collabs\\Custom Entities\\*.lua + [any files or subdirs]
+    - .\\Collabs\\Custom Props\\*.lua + [any files or subdirs]
+    - .\\User\\Decor\\*.json + [any files or subdirs]
+    - .\\User\\Locations\\*.json + [any files or subdirs]
+    - .\\User\\Scripts\\*.json + [any files or subdirs]
+    - .\\User\\Themes\\*.json + [any files or subdirs]
+  `,
+  Toplevel = `
+    - .\\[*.json or *.lua files that can be validated to be AMM format]
+  `,
 }
 
-export const AMM_MOD_CUSTOMS_CANON_DIR = path.join(`${AMM_BASEDIR_PATH}\\Collabs`);
-export const AMM_MOD_USERMOD_CANON_DIR = path.join(`${AMM_BASEDIR_PATH}\\User`);
+export const AMM_MOD_COLLAB_LUA_EXTENSION = `.lua`;
+export const AMM_MOD_USERMOD_JSON_EXTENSION = `.json`;
+
+export const AMM_MOD_CUSTOMS_DIRNAME = `Collabs`;
+export const AMM_MOD_USERMOD_DIRNAME = `User`;
+
+export const AMM_MOD_CUSTOMS_CANON_DIR = path.join(
+  AMM_BASEDIR_PATH,
+  AMM_MOD_CUSTOMS_DIRNAME,
+);
+export const AMM_MOD_USERMOD_CANON_DIR = path.join(
+  AMM_BASEDIR_PATH,
+  AMM_MOD_USERMOD_DIRNAME,
+);
 
 export const AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR = path.join(
   `${AMM_MOD_CUSTOMS_CANON_DIR}\\Custom Appearances`,

--- a/src/installers.shared.ts
+++ b/src/installers.shared.ts
@@ -13,16 +13,45 @@ import {
 import { InstallDecision, InstallerType } from "./installers.types";
 
 import { VortexApi, VortexInstruction } from "./vortex-wrapper";
+
 // Types
+export interface File {
+  readonly relativePath: string;
+  readonly pathOnDisk: string;
+  readonly content: string;
+}
 
-// Vortex gives us a 'destination path', which is actually
-// the tempdir in which the archive is expanded into for
-// the duration of the installation.
-export const makeSyntheticName = (vortexDestinationPath: string) =>
-  `${EXTENSION_NAME_INTERNAL}-${path.basename(vortexDestinationPath, ".installing")}`;
+export interface FileMove extends File {
+  readonly originalRelativePath: string;
+}
 
+export const fileFromDisk = (pathOnDisk: string, relativePath: string): Task<File> =>
+  T.map((content: string) => ({ relativePath, pathOnDisk, content }))(() =>
+    fs.readFile(pathOnDisk, `utf8`),
+  );
+
+export const fileMove = (to: string, file: File): FileMove => ({
+  relativePath: path.join(to, path.basename(file.relativePath)),
+  pathOnDisk: file.pathOnDisk,
+  originalRelativePath: file.relativePath,
+  content: file.content,
+});
+
+export const fileToInstruction = (movedFile: FileMove): VortexInstruction => ({
+  type: `copy`,
+  source: movedFile.originalRelativePath,
+  destination: movedFile.relativePath,
+});
+
+// For a synthetic mod name
+export const makeSyntheticName = (vortexStagingDirPath: string) =>
+  `${EXTENSION_NAME_INTERNAL}-${path.basename(vortexStagingDirPath)}`;
+
+//
 // Source to dest path mapping helpers
+
 export const toSamePath = (f: string) => [f, f];
+
 export const toDirInPath = (prefixPath: string, dir: string) => (f: string) =>
   [f, path.join(prefixPath, dir, path.basename(f))];
 
@@ -38,6 +67,9 @@ export const moveFromTo =
         .replace(path.normalize(fromPrefix), path.normalize(toPrefix)),
     ];
   };
+
+//
+// Instruction construction - DEPRECATE ME: use File/FileMove
 
 // Drop any folders and duplicates from the file list,
 // and then create the instructions.

--- a/src/installers.shared.ts
+++ b/src/installers.shared.ts
@@ -1,4 +1,9 @@
+import fs from "fs/promises";
 import path from "path";
+
+import { Task } from "fp-ts/lib/Task";
+import * as T from "fp-ts/Task";
+
 import { promptUserOnProtectedPaths } from "./ui.dialogs";
 import { FileTree, FILETREE_ROOT } from "./filetree";
 import { EXTENSION_NAME_INTERNAL } from "./index.metadata";

--- a/src/vortex-wrapper.ts
+++ b/src/vortex-wrapper.ts
@@ -35,6 +35,10 @@ export type VortexWrappedTestSupportedFunc = (
   vortexLog: VortexLogFunc,
   files: string[],
   fileTree: FileTree,
+  destinationPath?: string,
+  sourceDirPathForMod?: string,
+  stagingDirPathForMod?: string,
+  modName?: string,
 ) => Promise<VortexTestResult>;
 
 export type VortexInstallFunc = Vortex.InstallFunc;
@@ -49,6 +53,9 @@ export type VortexWrappedInstallFunc = (
   fileTree: FileTree,
   destinationPath: string,
   progressDelegate: VortexProgressDelegate,
+  sourceDirPathForMod: string,
+  stagingDirPathForMod: string,
+  modName: string,
   choices?: unknown,
   unattended?: boolean,
 ) => Promise<VortexInstallResult>;

--- a/test/unit/installer-pipeline.test.ts
+++ b/test/unit/installer-pipeline.test.ts
@@ -22,43 +22,16 @@ const fakeModZipfileStructure = FAKE_STAGING_PATH.split(path.sep).reduceRight<ob
 */
 
 describe("Transforming modules to instructions", () => {
-  beforeEach(() => {
-    mockFs({
-      unno: {
-        why: {
-          this: {
-            "vortexusesthezipfileasdir-3429 4": {
-              "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
-              "serious.ini": "[super serious]\nWings=false",
-              "superreshade.ini":
-                "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
-              fold1: {
-                "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
-                "serious.ini": "[super serious]\nWings=false",
-                "superreshade.ini":
-                  "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
-                "reshade-shaders": {
-                  Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-                  Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-                },
-              },
-              "reshade-shaders": {
-                Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-                Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-              },
-            },
-          },
-        },
-      },
-    });
-  });
-
   afterEach(() => mockFs.restore());
 
   AllExpectedSuccesses.forEach((examples, set) => {
     describe(`${set} mods`, () => {
       examples.forEach(async (mod, desc) => {
         test(`produce the expected instructions when ${desc}`, async () => {
+          if (mod.fsMocked) {
+            mockFs.restore();
+            mockFs(mod.fsMocked);
+          }
           //
           const mockVortexExtensionContext: DeepMockProxy<VortexExtensionContext> =
             mockDeep<VortexExtensionContext>();
@@ -118,6 +91,11 @@ describe("Transforming modules to instructions", () => {
     describe(`install attempts that should prompt to proceed/cancel, ${set}`, () => {
       examples.forEach(async (mod, desc) => {
         test(`proceeds to install when choosing to proceed on ${desc}`, async () => {
+          if (mod.fsMocked) {
+            mockFs.restore();
+            mockFs(mod.fsMocked);
+          }
+
           const mockResult: VortexDialogResult = {
             action: InstallChoices.Proceed,
             input: undefined,
@@ -157,6 +135,11 @@ describe("Transforming modules to instructions", () => {
         });
 
         test(`rejects the install when choosing to cancel on ${desc}`, async () => {
+          if (mod.fsMocked) {
+            mockFs.restore();
+            mockFs(mod.fsMocked);
+          }
+
           const mockResult: VortexDialogResult = {
             action: InstallChoices.Cancel,
             input: undefined,
@@ -194,6 +177,11 @@ describe("Transforming modules to instructions", () => {
     describe(`mods that installers reject without prompt, ${set}`, () => {
       examples.forEach((mod, desc) => {
         test(`rejects the install outright when ${desc}`, async () => {
+          if (mod.fsMocked) {
+            mockFs.restore();
+            mockFs(mod.fsMocked);
+          }
+
           //
           const mockVortexExtensionContext: DeepMockProxy<VortexExtensionContext> =
             mockDeep<VortexExtensionContext>();

--- a/test/unit/installer-pipeline.test.ts
+++ b/test/unit/installer-pipeline.test.ts
@@ -5,7 +5,7 @@ import { GAME_ID } from "../../src/index.metadata";
 import { internalPipelineInstaller, wrapInstall } from "../../src/installers";
 import { VortexDialogResult, VortexExtensionContext } from "../../src/vortex-wrapper";
 
-import { FAKE_STAGING_PATH, getMockVortexLog } from "./utils.helper";
+import { FAKE_STAGING_PATH, getMockVortexLog, sortByDestination } from "./utils.helper";
 
 import {
   AllExpectedDirectFailures,
@@ -90,7 +90,10 @@ describe("Transforming modules to instructions", () => {
             null,
           );
 
-          expect(installResult.instructions).toEqual(mod.outInstructions);
+          const gotInstructionsSorted = sortByDestination(installResult.instructions);
+          const expectedInstructionsSorted = sortByDestination(mod.outInstructions);
+
+          expect(gotInstructionsSorted).toEqual(expectedInstructionsSorted);
 
           if (mod.infoDialogTitle) {
             const actualCalls = dialogMock.mock.calls;
@@ -127,6 +130,11 @@ describe("Transforming modules to instructions", () => {
             .calledWith(notEmpty(), notEmpty(), notEmpty(), notEmpty())
             .mockReturnValue(Promise.resolve<VortexDialogResult>(mockResult));
 
+          const notificationMock =
+            mockVortexExtensionContext.api.sendNotification.calledWith(notEmpty());
+
+          notificationMock.mockReturnValue(`this doesn't actually matter, the call does`);
+
           const wrappedInstall = wrapInstall(
             mockVortexExtensionContext,
             { log: getMockVortexLog() },
@@ -140,7 +148,12 @@ describe("Transforming modules to instructions", () => {
             null,
           );
 
-          expect(installResult.instructions).toEqual(mod.proceedOutInstructions);
+          const gotInstructionsSorted = sortByDestination(installResult.instructions);
+          const expectedInstructionsSorted = sortByDestination(
+            mod.proceedOutInstructions,
+          );
+
+          expect(gotInstructionsSorted).toEqual(expectedInstructionsSorted);
         });
 
         test(`rejects the install when choosing to cancel on ${desc}`, async () => {
@@ -155,6 +168,11 @@ describe("Transforming modules to instructions", () => {
           mockVortexExtensionContext.api.showDialog
             .calledWith(notEmpty(), notEmpty(), notEmpty(), notEmpty())
             .mockReturnValue(Promise.resolve<VortexDialogResult>(mockResult));
+
+          const notificationMock =
+            mockVortexExtensionContext.api.sendNotification.calledWith(notEmpty());
+
+          notificationMock.mockReturnValue(`this doesn't actually matter, the call does`);
 
           const wrappedInstall = wrapInstall(
             mockVortexExtensionContext,

--- a/test/unit/mods.example.amm.ts
+++ b/test/unit/mods.example.amm.ts
@@ -1,6 +1,13 @@
 import path from "path";
 import {
   AMM_BASEDIR_PATH,
+  AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR,
+  AMM_MOD_CUSTOM_ENTITIES_CANON_DIR,
+  AMM_MOD_CUSTOM_PROPS_CANON_DIR,
+  AMM_MOD_DECOR_CANON_DIR,
+  AMM_MOD_LOCATIONS_CANON_DIR,
+  AMM_MOD_SCRIPTS_CANON_DIR,
+  AMM_MOD_THEMES_CANON_DIR,
   ARCHIVE_MOD_CANONICAL_PREFIX,
 } from "../../src/installers.layouts";
 import { InstallerType } from "../../src/installers.types";
@@ -16,6 +23,7 @@ import {
   expectedUserCancelMessageFor,
   movedFromTo,
   copiedToSamePath,
+  mockedFsLayout,
 } from "./utils.helper";
 
 const AMM_BASE_PREFIXES = pathHierarchyFor(AMM_BASEDIR_PATH);
@@ -391,48 +399,221 @@ const AmmModNonConformingCanonDirOnlyLayoutsPromptToInstall = new Map<
   ],
 ]);
 
-/*
+const minimalCustomAppearanceLua = `
+return {
+  modder = "DC",
+  unique_identifier = "ClarkKent",
+  entity_id = "0xDEADBEEF, 99",
+  appearances = {
+    "glassesitsliterallyjustglasses"
+  },
+}
+`;
+
+const minimalCustomEntityLua = `
+return {
+  modder = "ray",
+  unique_identifier = "itsactuallyanapparition",
+  entity_info = { dunno something goes here probably }
+}`;
+
+const minimalCustomPropLua = `
+return {
+  modder = "cessna",
+  unique_identifier = "piper",
+  props = {...this shouldn't really matter....}
+}`;
+
+const minimalDecorJson = JSON.stringify({
+  name: "custdecor",
+  props: [],
+  lights: [],
+  customIncluded: false,
+});
+const minimalLocationJson = JSON.stringify({
+  x: 1,
+  y: 2,
+  z: 3,
+});
+const minimalScriptJson = JSON.stringify({
+  title: `somescripttitle`,
+  actors: [],
+});
+const minimalThemeJson = JSON.stringify({
+  Text: [],
+  Border: [],
+});
+
 const AmmModToplevelsMatchingSchemaInstallSucceeds = new Map<
   string,
   ExampleSucceedingMod
 >([
   [
-    `customs and user stuffs identified in canonical location for type (plus archives)`,
+    `top-level custom appearance recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custapp.lua`)],
+      fsMocked: mockedFsLayout({ "custapp.lua": minimalCustomAppearanceLua }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custapp.lua`),
+          path.join(`${AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR}\\custapp.lua`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level custom entity recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custent.lua`)],
+      fsMocked: mockedFsLayout({ "custent.lua": minimalCustomEntityLua }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custent.lua`),
+          path.join(`${AMM_MOD_CUSTOM_ENTITIES_CANON_DIR}\\custent.lua`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level custom prop recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custprop.lua`)],
+      fsMocked: mockedFsLayout({ "custprop.lua": minimalCustomPropLua }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custprop.lua`),
+          path.join(`${AMM_MOD_CUSTOM_PROPS_CANON_DIR}\\custprop.lua`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level decor json recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custdec.json`)],
+      fsMocked: mockedFsLayout({ "custdec.json": minimalDecorJson }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custdec.json`),
+          path.join(`${AMM_MOD_DECOR_CANON_DIR}\\custdec.json`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level location json recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custloc.json`)],
+      fsMocked: mockedFsLayout({ "custloc.json": minimalLocationJson }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custloc.json`),
+          path.join(`${AMM_MOD_LOCATIONS_CANON_DIR}\\custloc.json`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level script json recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custscript.json`)],
+      fsMocked: mockedFsLayout({ "custscript.json": minimalScriptJson }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custscript.json`),
+          path.join(`${AMM_MOD_SCRIPTS_CANON_DIR}\\custscript.json`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level theme json recognized and moved to canonical dir`,
+    {
+      expectedInstallerType: InstallerType.AMM,
+      inFiles: [path.join(`.\\custtheme.json`)],
+      fsMocked: mockedFsLayout({ "custtheme.json": minimalThemeJson }),
+      outInstructions: [
+        movedFromTo(
+          path.join(`.\\custtheme.json`),
+          path.join(`${AMM_MOD_THEMES_CANON_DIR}\\custtheme.json`),
+        ),
+      ],
+    },
+  ],
+  [
+    `top-level combinations recognized and all moved to correct canonical dirs, including archives`,
     {
       expectedInstallerType: InstallerType.AMM,
       inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
-        ...ARCHIVE_PREFIXES,
-        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+        path.join(`.\\custdec.json`),
+        path.join(`.\\custloc.json`),
+        path.join(`.\\custtheme.json`),
+        path.join(`.\\custscript.json`),
+        path.join(`.\\custprop.lua`),
+        path.join(`.\\custent.lua`),
+        path.join(`.\\custapp.lua`),
+        path.join(`.\\some.archive`),
       ],
+      fsMocked: mockedFsLayout({
+        "custdec.json": minimalDecorJson,
+        "custloc.json": minimalLocationJson,
+        "custtheme.json": minimalThemeJson,
+        "custscript.json": minimalScriptJson,
+        "custprop.lua": minimalCustomPropLua,
+        "custent.lua": minimalCustomEntityLua,
+        "custapp.lua": minimalCustomAppearanceLua,
+        // No archive required here
+      }),
       outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
-
-        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+        movedFromTo(
+          path.join(`.\\custdec.json`),
+          path.join(`${AMM_MOD_DECOR_CANON_DIR}\\custdec.json`),
+        ),
+        movedFromTo(
+          path.join(`.\\custloc.json`),
+          path.join(`${AMM_MOD_LOCATIONS_CANON_DIR}\\custloc.json`),
+        ),
+        movedFromTo(
+          path.join(`.\\custtheme.json`),
+          path.join(`${AMM_MOD_THEMES_CANON_DIR}\\custtheme.json`),
+        ),
+        movedFromTo(
+          path.join(`.\\custscript.json`),
+          path.join(`${AMM_MOD_SCRIPTS_CANON_DIR}\\custscript.json`),
+        ),
+        movedFromTo(
+          path.join(`.\\custprop.lua`),
+          path.join(`${AMM_MOD_CUSTOM_PROPS_CANON_DIR}\\custprop.lua`),
+        ),
+        movedFromTo(
+          path.join(`.\\custent.lua`),
+          path.join(`${AMM_MOD_CUSTOM_ENTITIES_CANON_DIR}\\custent.lua`),
+        ),
+        movedFromTo(
+          path.join(`.\\custapp.lua`),
+          path.join(`${AMM_MOD_CUSTOM_APPEARANCES_CANON_DIR}\\custapp.lua`),
+        ),
+        movedFromTo(
+          path.join(`.\\some.archive`),
+          path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\some.archive`),
+        ),
       ],
     },
   ],
 ]);
-*/
 
 const examples: ExamplesForType = {
   AllExpectedSuccesses: mergeOrFailOnConflict(
     AmmModCanonicalCollabsInstallSucceeds,
     AmmModCanonicalUserStuffModsInstallSucceeds,
     AmmModCanonicalCombinationsInstallSucceeds,
+    AmmModToplevelsMatchingSchemaInstallSucceeds,
   ),
   AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
   AllExpectedPromptInstalls: mergeOrFailOnConflict(

--- a/test/unit/mods.example.amm.ts
+++ b/test/unit/mods.example.amm.ts
@@ -11,218 +11,373 @@ import {
   ExampleFailingMod,
   ExamplePromptInstallableMod,
   pathHierarchyFor,
-  copiedToSamePath,
   ARCHIVE_PREFIXES,
   mergeOrFailOnConflict,
   expectedUserCancelMessageFor,
+  movedFromTo,
+  copiedToSamePath,
 } from "./utils.helper";
 
 const AMM_BASE_PREFIXES = pathHierarchyFor(AMM_BASEDIR_PATH);
 
-const AmmModCanonicalCollabsInstallSucceeds = new Map<string, ExampleSucceedingMod>([
-  [
-    `custom appearance lua in canonical location`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
-      ],
-      outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`),
-      ],
-    },
-  ],
-  [
-    `custom entity lua in canonical location`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-      ],
-      outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-      ],
-    },
-  ],
-  [
-    `custom prop lua in canonical location`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-      ],
-      outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-      ],
-    },
-  ],
-  [
-    `custom combinations in canonical location`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-      ],
-      outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-      ],
-    },
-  ],
-  [
-    `customs including extra archives in canonical location`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        ...ARCHIVE_PREFIXES,
-        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
-      ],
-      outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
-      ],
-    },
-  ],
-]);
+const AMM_CANON_AND_TOPLEVEL_TEST_PREFIXES = [
+  {
+    kind: `canonical`,
+    ammPrefixes: AMM_BASE_PREFIXES,
+    ammPrefix: AMM_BASEDIR_PATH,
+    archivePrefixes: ARCHIVE_PREFIXES,
+    archivePrefix: ARCHIVE_MOD_CANONICAL_PREFIX,
+    expectedNoMatchPromptType: InstallerType.AMM,
+  },
+  {
+    kind: `toplevel canonical subdir`,
+    ammPrefixes: [],
+    ammPrefix: `.`,
+    archivePrefixes: [],
+    archivePrefix: `.`,
+    expectedNoMatchPromptType: InstallerType.Fallback,
+  },
+];
 
-const AmmModCanonicalUserStuffModsInstallSucceeds = new Map<string, ExampleSucceedingMod>(
-  [
-    [
-      `decor json in canonical location`,
-      {
-        expectedInstallerType: InstallerType.AMM,
-        inFiles: [
-          ...AMM_BASE_PREFIXES,
-          path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        ],
-        outInstructions: [
-          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        ],
-      },
+const AmmModCanonicalCollabsInstallSucceeds = new Map<string, ExampleSucceedingMod>(
+  AMM_CANON_AND_TOPLEVEL_TEST_PREFIXES.flatMap(
+    ({ kind, ammPrefixes, ammPrefix, archivePrefixes, archivePrefix }) => [
+      [
+        `custom appearance lua in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Appearances\\custapp.lua`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Appearances\\custapp.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Appearances\\custapp.lua`,
+            ),
+          ],
+        },
+      ],
+      [
+        `custom entity lua in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`,
+            ),
+          ],
+        },
+      ],
+      [
+        `custom prop lua in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`,
+            ),
+          ],
+        },
+      ],
+      [
+        `custom combinations in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+            path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`,
+            ),
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`,
+            ),
+          ],
+        },
+      ],
+      [
+        `customs including extra archives in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+            ...archivePrefixes,
+            path.join(`${archivePrefix}\\custent.archive`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`,
+            ),
+            movedFromTo(
+              path.join(`${archivePrefix}\\custent.archive`),
+              `${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`,
+            ),
+          ],
+        },
+      ],
     ],
-    [
-      `location json in canonical location`,
-      {
-        expectedInstallerType: InstallerType.AMM,
-        inFiles: [
-          ...AMM_BASE_PREFIXES,
-          path.join(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
-        ],
-        outInstructions: [
-          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`),
-        ],
-      },
-    ],
-    [
-      `script json in canonical location`,
-      {
-        expectedInstallerType: InstallerType.AMM,
-        inFiles: [
-          ...AMM_BASE_PREFIXES,
-          path.join(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
-        ],
-        outInstructions: [
-          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
-        ],
-      },
-    ],
-    [
-      `theme json in canonical location`,
-      {
-        expectedInstallerType: InstallerType.AMM,
-        inFiles: [
-          ...AMM_BASE_PREFIXES,
-          path.join(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
-        ],
-        outInstructions: [
-          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
-        ],
-      },
-    ],
-    [
-      `user things combined in canonical location`,
-      {
-        expectedInstallerType: InstallerType.AMM,
-        inFiles: [
-          ...AMM_BASE_PREFIXES,
-          path.join(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
-          path.join(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
-        ],
-        outInstructions: [
-          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`),
-          copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`),
-        ],
-      },
-    ],
-  ],
+  ),
 );
 
-const AmmModCanonicalCombinationsInstallSucceeds = new Map<string, ExampleSucceedingMod>([
-  [
-    `combining canonicals`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        ...ARCHIVE_PREFIXES,
-        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+const AmmModCanonicalUserStuffModsInstallSucceeds = new Map<string, ExampleSucceedingMod>(
+  AMM_CANON_AND_TOPLEVEL_TEST_PREFIXES.flatMap(
+    ({ kind, ammPrefixes, ammPrefix, archivePrefixes, archivePrefix }) => [
+      [
+        `decor json in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\User\\Decor\\custdecor.json`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Decor\\custdecor.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`,
+            ),
+          ],
+        },
       ],
-      outInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
+      [
+        `location json in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [...ammPrefixes, path.join(`${ammPrefix}\\User\\Locations\\loc.json`)],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Locations\\loc.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Locations\\loc.json`,
+            ),
+          ],
+        },
       ],
-    },
-  ],
-]);
+      [
+        `script json in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\User\\Scripts\\weeflekit.json`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Scripts\\weeflekit.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`,
+            ),
+          ],
+        },
+      ],
+      [
+        `theme json in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\User\\Themes\\mytheme.json`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              `${ammPrefix}\\User\\Themes\\mytheme.json`,
+              `${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`,
+            ),
+          ],
+        },
+      ],
+      [
+        `user things combined in ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\User\\Themes\\mytheme.json`),
+            path.join(`${ammPrefix}\\User\\Scripts\\weeflekit.json`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Themes\\mytheme.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`,
+            ),
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Scripts\\weeflekit.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`,
+            ),
+          ],
+        },
+      ],
+      [
+        `user things combined in ${kind}, with archives`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\User\\Themes\\mytheme.json`),
+            path.join(`${ammPrefix}\\User\\Scripts\\weeflekit.json`),
+            ...archivePrefixes,
+            path.join(`${archivePrefix}\\weeflekit.archive`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Themes\\mytheme.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Themes\\mytheme.json`,
+            ),
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Scripts\\weeflekit.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Scripts\\weeflekit.json`,
+            ),
+            movedFromTo(
+              path.join(`${archivePrefix}\\weeflekit.archive`),
+              `${ARCHIVE_MOD_CANONICAL_PREFIX}\\weeflekit.archive`,
+            ),
+          ],
+        },
+      ],
+    ],
+  ),
+);
+
+const AmmModCanonicalCombinationsInstallSucceeds = new Map<string, ExampleSucceedingMod>(
+  AMM_CANON_AND_TOPLEVEL_TEST_PREFIXES.flatMap(
+    ({ kind, ammPrefixes, ammPrefix, archivePrefixes, archivePrefix }) => [
+      [
+        `combining ${kind} AMMs`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+            path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+            path.join(`${ammPrefix}\\User\\Decor\\custdecor.json`),
+            ...archivePrefixes,
+            path.join(`${archivePrefix}\\custent.archive`),
+          ],
+          outInstructions: [
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`,
+            ),
+            movedFromTo(
+              path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+              `${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`,
+            ),
+            movedFromTo(
+              path.join(`${ammPrefix}\\User\\Decor\\custdecor.json`),
+              `${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`,
+            ),
+            movedFromTo(
+              path.join(`${archivePrefix}\\custent.archive`),
+              `${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`,
+            ),
+          ],
+        },
+      ],
+    ],
+  ),
+);
 
 const AmmModNonConformingLayoutsPromptToInstall = new Map<
   string,
   ExamplePromptInstallableMod
+>(
+  AMM_CANON_AND_TOPLEVEL_TEST_PREFIXES.flatMap(
+    ({
+      kind,
+      ammPrefixes,
+      ammPrefix,
+      archivePrefixes,
+      archivePrefix,
+      expectedNoMatchPromptType,
+    }) => [
+      [
+        `luas in user dir prompt with ${expectedNoMatchPromptType} to install since should be jsons present at least for ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\User\\Decor\\custdecor.lua`),
+          ],
+          proceedLabel: InstallChoices.Proceed,
+          proceedOutInstructions: [
+            copiedToSamePath(path.join(`${ammPrefix}\\User\\Decor\\custdecor.lua`)),
+          ],
+          cancelLabel: InstallChoices.Cancel,
+          cancelErrorMessage: expectedUserCancelMessageFor(expectedNoMatchPromptType),
+        },
+      ],
+      [
+        `jsons in collabs dir prompt with ${expectedNoMatchPromptType} to install since should be luas present at least for ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Props\\custdecor.json`),
+          ],
+          proceedLabel: InstallChoices.Proceed,
+          proceedOutInstructions: [
+            copiedToSamePath(
+              path.join(`${ammPrefix}\\Collabs\\Custom Props\\custdecor.json`),
+            ),
+          ],
+          cancelLabel: InstallChoices.Cancel,
+          cancelErrorMessage: expectedUserCancelMessageFor(expectedNoMatchPromptType),
+        },
+      ],
+      [
+        `files in AMM basedir even if there are other, supported files in correct places for ${kind}`,
+        {
+          expectedInstallerType: InstallerType.AMM,
+          inFiles: [
+            ...ammPrefixes,
+            path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+            path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+            path.join(`${ammPrefix}\\User\\Decor\\custdecor.json`),
+            path.join(`${ammPrefix}\\wtf.md`),
+            path.join(`${ammPrefix}\\swhatisaid.lua`),
+            ...archivePrefixes,
+            path.join(`${archivePrefix}\\custent.archive`),
+          ],
+          proceedLabel: InstallChoices.Proceed,
+          proceedOutInstructions: [
+            copiedToSamePath(
+              path.join(`${ammPrefix}\\Collabs\\Custom Props\\custprop.lua`),
+            ),
+            copiedToSamePath(
+              path.join(`${ammPrefix}\\Collabs\\Custom Entities\\custent.lua`),
+            ),
+            copiedToSamePath(path.join(`${ammPrefix}\\User\\Decor\\custdecor.json`)),
+            copiedToSamePath(path.join(`${ammPrefix}\\wtf.md`)),
+            copiedToSamePath(path.join(`${ammPrefix}\\swhatisaid.lua`)),
+            copiedToSamePath(path.join(`${archivePrefix}\\custent.archive`)),
+          ],
+          cancelLabel: InstallChoices.Cancel,
+          cancelErrorMessage: expectedUserCancelMessageFor(expectedNoMatchPromptType),
+        },
+      ],
+    ],
+  ),
+);
+
+const AmmModNonConformingCanonDirOnlyLayoutsPromptToInstall = new Map<
+  string,
+  ExamplePromptInstallableMod
 >([
-  [
-    `luas in user dir prompt to install since should be jsons present at least`,
-    {
-      expectedInstallerType: InstallerType.CoreAmm,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.lua`),
-      ],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.lua`),
-      ],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
-    },
-  ],
-  [
-    `jsons in collabs dir prompt to install since should be luas present at least`,
-    {
-      expectedInstallerType: InstallerType.CoreAmm,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custdecor.json`),
-      ],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custdecor.json`),
-      ],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
-    },
-  ],
   [
     `files in AMM basedir only even if possibly supported`,
     {
@@ -230,33 +385,6 @@ const AmmModNonConformingLayoutsPromptToInstall = new Map<
       inFiles: [...AMM_BASE_PREFIXES, path.join(`${AMM_BASEDIR_PATH}\\noidea.lua`)],
       proceedLabel: InstallChoices.Proceed,
       proceedOutInstructions: [copiedToSamePath(`${AMM_BASEDIR_PATH}\\noidea.lua`)],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
-    },
-  ],
-  [
-    `files in AMM basedir even if there are other, supported files in correct places`,
-    {
-      expectedInstallerType: InstallerType.AMM,
-      inFiles: [
-        ...AMM_BASE_PREFIXES,
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        path.join(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        path.join(`${AMM_BASEDIR_PATH}\\wtf.md`),
-        path.join(`${AMM_BASEDIR_PATH}\\swhatisaid.lua`),
-        ...ARCHIVE_PREFIXES,
-        path.join(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
-      ],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\wtf.md`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\swhatisaid.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Props\\custprop.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\Collabs\\Custom Entities\\custent.lua`),
-        copiedToSamePath(`${AMM_BASEDIR_PATH}\\User\\Decor\\custdecor.json`),
-        copiedToSamePath(`${ARCHIVE_MOD_CANONICAL_PREFIX}\\custent.archive`),
-      ],
       cancelLabel: InstallChoices.Cancel,
       cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.AMM),
     },
@@ -309,6 +437,7 @@ const examples: ExamplesForType = {
   AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
   AllExpectedPromptInstalls: mergeOrFailOnConflict(
     AmmModNonConformingLayoutsPromptToInstall,
+    AmmModNonConformingCanonDirOnlyLayoutsPromptToInstall,
   ),
 };
 

--- a/test/unit/mods.example.config.json.ts
+++ b/test/unit/mods.example.config.json.ts
@@ -18,7 +18,10 @@ import {
   copiedToSamePath,
   mergeOrFailOnConflict,
   expectedUserCancelProtectedMessageFor,
+  mockedFsLayout,
 } from "./utils.helper";
+
+const RANDOM_FAKE_JSON = JSON.stringify({ empty: true });
 
 const JsonModShouldPromptOnProtected = new Map<string, ExamplePromptInstallableMod>(
   CONFIG_JSON_MOD_PROTECTED_FILES.map((protectedPath) => [
@@ -44,6 +47,8 @@ const JsonModShouldPromptOnProtectedFilenameToplevelFixables = new Map<
       expectedInstallerType: InstallerType.ConfigJson,
       proceedLabel: InstallChoices.Proceed,
       inFiles: [path.join(protectedName)],
+      // AMM also looks at these
+      fsMocked: mockedFsLayout(Object.fromEntries([[protectedName, RANDOM_FAKE_JSON]])),
       proceedOutInstructions: [
         {
           type: `copy`,
@@ -70,6 +75,8 @@ const JsonModShouldPromptOnProtectedFilenameToplevelUnfixables = new Map<
       expectedInstallerType: InstallerType.ConfigJson,
       proceedLabel: InstallChoices.Proceed,
       inFiles: [path.join(protectedName)],
+      // AMM also looks at these
+      fsMocked: mockedFsLayout(Object.fromEntries([[protectedName, RANDOM_FAKE_JSON]])),
       proceedOutInstructions: [copiedToSamePath(path.join(protectedName))],
       cancelLabel: InstallChoices.Cancel,
       cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.ConfigJson),

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -25,6 +25,7 @@ import {
   expectedUserCancelProtectedMessageFor,
   FAKE_MOD_NAME,
   FAKE_STAGING_PATH,
+  mockedFsLayout,
   GAME_DIR,
   GIFTWRAP_PREFIX,
   MockFsDirItems,
@@ -1532,34 +1533,26 @@ const ConfigXmlModShouldPromptToInstall = new Map<string, ExamplePromptInstallab
   ],
 ]);
 
-const iniFsMock: MockFsDirItems = {
-  unno: {
-    why: {
-      this: {
-        "vortexusesthezipfileasdir-3429 4": {
-          "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
-          "serious.ini": "[super serious]\nWings=false",
-          "superreshade.ini":
-            "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
-          fold1: {
-            "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
-            "serious.ini": "[super serious]\nWings=false",
-            "superreshade.ini":
-              "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
-            "reshade-shaders": {
-              Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-              Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-            },
-          },
-          "reshade-shaders": {
-            Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-            Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
-          },
-        },
-      },
+const iniFsMock: MockFsDirItems = mockedFsLayout({
+  "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
+  "serious.ini": "[super serious]\nWings=false",
+  "superreshade.ini":
+    "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
+  fold1: {
+    "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
+    "serious.ini": "[super serious]\nWings=false",
+    "superreshade.ini":
+      "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
+    "reshade-shaders": {
+      Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+      Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
     },
   },
-};
+  "reshade-shaders": {
+    Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+    Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+  },
+});
 
 const IniMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -27,6 +27,7 @@ import {
   FAKE_STAGING_PATH,
   GAME_DIR,
   GIFTWRAP_PREFIX,
+  MockFsDirItems,
   pathHierarchyFor,
   RED4EXT_GIFTWRAPS,
   RED4EXT_PREFIX,
@@ -52,6 +53,10 @@ import {
 } from "../../src/installers.layouts";
 import { InstallChoices } from "../../src/ui.dialogs";
 import { InstallerType } from "../../src/installers.types";
+
+//
+// Mods
+//
 
 const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
@@ -1527,11 +1532,41 @@ const ConfigXmlModShouldPromptToInstall = new Map<string, ExamplePromptInstallab
   ],
 ]);
 
+const iniFsMock: MockFsDirItems = {
+  unno: {
+    why: {
+      this: {
+        "vortexusesthezipfileasdir-3429 4": {
+          "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
+          "serious.ini": "[super serious]\nWings=false",
+          "superreshade.ini":
+            "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
+          fold1: {
+            "myawesomeconfig.ini": "[Secret setting]\nFrogs=Purple",
+            "serious.ini": "[super serious]\nWings=false",
+            "superreshade.ini":
+              "KeyPCGI_One@RadiantGI.fx=46,0,0,0\nPreprocessorDefinitions=SMOOTHNORMALS=1",
+            "reshade-shaders": {
+              Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+              Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+            },
+          },
+          "reshade-shaders": {
+            Shaders: { "fancy.fx": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+            Textures: { "lut.png": Buffer.from([8, 6, 7, 5, 3, 0, 9]) },
+          },
+        },
+      },
+    },
+  },
+};
+
 const IniMod = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     iniWithSingleIniAtRoot: {
       expectedInstallerType: InstallerType.INI,
       inFiles: ["myawesomeconfig.ini"].map(path.normalize),
+      fsMocked: iniFsMock,
       outInstructions: [
         {
           type: "copy",
@@ -1543,6 +1578,7 @@ const IniMod = new Map<string, ExampleSucceedingMod>(
     iniWithMultipleIniAtRoot: {
       expectedInstallerType: InstallerType.INI,
       inFiles: ["myawesomeconfig.ini", "serious.ini"].map(path.normalize),
+      fsMocked: iniFsMock,
       outInstructions: [
         {
           type: "copy",
@@ -1559,6 +1595,7 @@ const IniMod = new Map<string, ExampleSucceedingMod>(
     iniWithReshadeIniAtRoot: {
       expectedInstallerType: InstallerType.INI,
       inFiles: ["superreshade.ini"].map(path.normalize),
+      fsMocked: iniFsMock,
       outInstructions: [
         {
           type: "copy",
@@ -1570,6 +1607,7 @@ const IniMod = new Map<string, ExampleSucceedingMod>(
     iniWithSingleIniInRandomFolder: {
       expectedInstallerType: InstallerType.INI,
       inFiles: ["fold1/", "fold1/myawesomeconfig.ini"].map(path.normalize),
+      fsMocked: iniFsMock,
       outInstructions: [
         {
           type: "copy",
@@ -1588,6 +1626,7 @@ const IniMod = new Map<string, ExampleSucceedingMod>(
         "reshade-shaders/Textures/",
         "reshade-shaders/Textures/lut.png",
       ].map(path.normalize),
+      fsMocked: iniFsMock,
       outInstructions: [
         {
           type: "copy",
@@ -1620,6 +1659,7 @@ const IniMod = new Map<string, ExampleSucceedingMod>(
         "fold1/reshade-shaders/Textures/",
         "fold1/reshade-shaders/Textures/lut.png",
       ].map(path.normalize),
+      fsMocked: iniFsMock,
       outInstructions: [
         {
           type: "copy",

--- a/test/unit/utils.helper.ts
+++ b/test/unit/utils.helper.ts
@@ -22,10 +22,15 @@ import { InfoNotification } from "../../src/ui.notifications";
 //
 
 export type InFiles = string[];
+// Should replace this with the real mock-fs type
+export interface MockFsDirItems {
+  [dir: string]: string | Buffer | MockFsDirItems;
+}
 
 interface ExampleMod {
   expectedInstallerType: InstallerType;
   inFiles: InFiles;
+  fsMocked?: MockFsDirItems;
 }
 
 export interface ExampleSucceedingMod extends ExampleMod {

--- a/test/unit/utils.helper.ts
+++ b/test/unit/utils.helper.ts
@@ -189,3 +189,13 @@ export const RED4EXT_GIFTWRAPS = pathHierarchyFor(
 export const ARCHIVE_GIFTWRAPS = pathHierarchyFor(
   `${GIFTWRAP_PREFIX}\\${ARCHIVE_PREFIX}`,
 );
+
+//
+// Actual test helpers
+//
+
+export const compareByDestination = (a: VortexInstruction, b: VortexInstruction) =>
+  a.destination.localeCompare(b.destination);
+
+export const sortByDestination = (instructions: VortexInstruction[]) =>
+  instructions.sort(compareByDestination);

--- a/test/unit/utils.helper.ts
+++ b/test/unit/utils.helper.ts
@@ -78,10 +78,6 @@ export const mergeOrFailOnConflict = <K, V>(...maps: Map<K, V>[]): Map<K, V> =>
     return new Map([...mergedMap, ...map]);
   }, new Map<K, V>());
 
-//
-// Test support functions, mocks
-//
-
 // This is the most nonsense of all nonsense, but under some
 // conditions it seems to be possible for jest to override
 // `console`...
@@ -102,6 +98,32 @@ export const getMockVortexLog = () => {
 
   return mockLog;
 };
+
+//
+// Mod path stuff
+//
+
+const FAKE_STAGING_ZIPFILE = path.normalize("vortexusesthezipfileandmodidasdir-7536");
+const FAKE_STAGING_DIRS = [`some`, `dirs`, `to`, `stage`, FAKE_STAGING_ZIPFILE];
+
+export const FAKE_STAGING_PATH = path.join(...FAKE_STAGING_DIRS, path.sep);
+// This will be derived from the staging path
+export const FAKE_MOD_NAME = `${EXTENSION_NAME_INTERNAL}-${FAKE_STAGING_ZIPFILE}`;
+
+//
+// Test support functions, mocks
+//
+
+// Should actually maybe just use this outright for everything based on `inFiles`
+// because it's possible we're looking at the fs - as we do for INIs and AMM. But
+// that'll require adding a default before/afterEach to clear them out.
+//
+// Improvement: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/158
+export const mockedFsLayout = (layout: MockFsDirItems = {}): MockFsDirItems =>
+  FAKE_STAGING_DIRS.reduceRight(
+    (inner, dir) => Object.fromEntries([[dir, inner]]),
+    layout,
+  );
 
 export const pathHierarchyFor = (entirePath: string): string[] => {
   const pathSegments = path.normalize(entirePath).split(path.sep);
@@ -147,16 +169,6 @@ export const expectedUserCancelProtectedMessageInMultiType = `${InstallerType.Mu
 //
 // Path helpers etc.
 //
-
-export const FAKE_STAGING_ZIPFILE = path.normalize("vortexusesthezipfileasdir-3429 4");
-export const FAKE_STAGING_PATH = path.join(
-  "unno",
-  "why",
-  "this",
-  FAKE_STAGING_ZIPFILE,
-  path.sep,
-);
-export const FAKE_MOD_NAME = `${EXTENSION_NAME_INTERNAL}-${FAKE_STAGING_ZIPFILE}`;
 
 export const CORE_CET_FULL_PATH_DEPTH = path.normalize(
   "bin/x64/plugins/cyber_engine_tweaks/scripts/json",


### PR DESCRIPTION
Handling for AMM stuff at toplevel. The flat toplevel files introduce another place where we parse content, because the .json and .lua could be something else too.

- [x] Toplevel canonical subdirs like `.\\Collab\\...`
- [x] Toplevel only
- [x] Multiple kinds at toplevel incl. archives (Cybernoir)

Other random stuff:

- Added `fp-ts` because trying to handle regular TS arrays in async was getting real old
- `mockedFsLayout` to create mock-fs structures in tests, just give your specific files
- out instructions order doesn't matter anymore, they're compared sorted

Closes #141 
Closes #152 