### PR TITLE
🐛 Redscript Can Be Nested Arbitrarily Deep

### DIFF
--- a/src/installer.redscript.ts
+++ b/src/installer.redscript.ts
@@ -3,8 +3,8 @@ import {
   FileTree,
   dirWithSomeIn,
   filesUnder,
+  findTopmostSubdirsWithSome,
   Glob,
-  findDirectSubdirsWithSome,
   FILETREE_ROOT,
 } from "./filetree";
 import { extraCanonArchiveInstructions } from "./installer.archive";
@@ -40,7 +40,7 @@ const matchRedscript = (file: string) =>
 const allRedscriptFiles = (files: string[]): string[] => files.filter(matchRedscript);
 
 const findCanonicalRedscriptDirs = (fileTree: FileTree) =>
-  findDirectSubdirsWithSome(REDS_MOD_CANONICAL_PATH_PREFIX, matchRedscript, fileTree);
+  findTopmostSubdirsWithSome(REDS_MOD_CANONICAL_PATH_PREFIX, matchRedscript, fileTree);
 
 export const detectRedscriptBasedirLayout = (fileTree: FileTree): boolean =>
   dirWithSomeIn(REDS_MOD_CANONICAL_PATH_PREFIX, matchRedscript, fileTree);

--- a/src/installer.redscript.ts
+++ b/src/installer.redscript.ts
@@ -15,14 +15,14 @@ import {
   NoInstructions,
   RedscriptLayout,
   REDS_MOD_CANONICAL_EXTENSION,
-  LayoutToInstructions,
+  InvalidLayout,
 } from "./installers.layouts";
 import {
   moveFromTo,
   instructionsForSourceToDestPairs,
   instructionsForSameSourceAndDestPaths,
   makeSyntheticName,
-  useAllMatchingLayouts,
+  useFirstMatchingLayoutForInstructions,
 } from "./installers.shared";
 import { InstallerType } from "./installers.types";
 import {
@@ -94,7 +94,6 @@ export const redscriptToplevelLayout = (
   fileTree: FileTree,
 ): MaybeInstructions => {
   // .\*.reds
-  // eslint-disable-next-line no-underscore-dangle
   const hasToplevelReds = detectRedscriptToplevelLayout(fileTree);
 
   const toplevelReds = hasToplevelReds
@@ -102,23 +101,6 @@ export const redscriptToplevelLayout = (
     : [];
 
   if (!hasToplevelReds) {
-    api.log("debug", "No toplevel Redscript files found");
-    return NoInstructions.NoMatch;
-  }
-
-  // This is maybe slightly annoying to check, but makes
-  // logic elsewhere cleaner. I suppose we can decide that
-  // layouts need to be robust enough in themselves if they
-  // would otherwise depend on some external check that isn't
-  // always present.
-  //
-  // Generally, shouldn't get here.
-  //
-  const hasBasedirReds = detectRedscriptBasedirLayout(fileTree);
-
-  if (hasBasedirReds) {
-    // Errors need to be handled downstream if it's relevant there
-    api.log("debug", "No instructions from canon: basedir overrides");
     return NoInstructions.NoMatch;
   }
 
@@ -144,23 +126,6 @@ export const redscriptCanonLayout = (
   );
 
   if (allCanonRedscriptFiles.length < 1) {
-    api.log("error", "No canonical Redscript files found.");
-    return NoInstructions.NoMatch;
-  }
-
-  // This is maybe slightly annoying to check, but makes
-  // logic elsewhere cleaner. I suppose we can decide that
-  // layouts need to be robust enough in themselves if they
-  // would otherwise depend on some external check that isn't
-  // always present.
-  //
-  // Generally, shouldn't get here.
-  //
-  const hasBasedirReds = detectRedscriptBasedirLayout(fileTree);
-
-  if (hasBasedirReds) {
-    // Errors need to be handled downstream if it's relevant there
-    api.log("debug", "No instructions from canon: basedir overrides");
     return NoInstructions.NoMatch;
   }
 
@@ -170,7 +135,15 @@ export const redscriptCanonLayout = (
   };
 };
 
-export const testForRedscriptMod: VortexWrappedTestSupportedFunc = (
+//
+// API
+//
+
+//
+// testSupport
+//
+
+export const testForRedscriptMod: VortexWrappedTestSupportedFunc = async (
   api: VortexApi,
   log: VortexLogFunc,
   files: string[],
@@ -178,25 +151,17 @@ export const testForRedscriptMod: VortexWrappedTestSupportedFunc = (
 ): Promise<VortexTestResult> => {
   const redscriptFiles = allRedscriptFiles(files);
 
-  log("debug", "redscriptFiles: ", { redscriptFiles });
-
-  // We could do more detection here but the
-  // installer will already need to duplicate
-  // all that. Maybe just check whether there
-  // are any counterindications?
-  if (redscriptFiles.length === 0) {
-    log("debug", "No Redscripts");
-    return Promise.resolve({ supported: false, requiredFiles: [] });
+  if (redscriptFiles.length < 1) {
+    return { supported: false, requiredFiles: [] };
   }
 
-  log("info", "Matched to Redscript");
-  return Promise.resolve({
-    supported: true,
-    requiredFiles: [],
-  });
+  return { supported: true, requiredFiles: [] };
 };
 
-// Install the Redscript stuff, as well as any archives we find
+//
+// install
+//
+
 export const installRedscriptMod: VortexWrappedInstallFunc = async (
   api: VortexApi,
   _log: VortexLogFunc,
@@ -204,34 +169,19 @@ export const installRedscriptMod: VortexWrappedInstallFunc = async (
   fileTree: FileTree,
   destinationPath: string,
 ): Promise<VortexInstallResult> => {
-  // We could get a lot fancier here, but for now we don't accept
-  // subdirectories anywhere other than in a canonical location.
-
   const modName = makeSyntheticName(destinationPath);
 
-  const allInstructionSets: LayoutToInstructions[] = [
-    redscriptToplevelLayout,
-    redscriptBasedirLayout,
-    redscriptCanonLayout,
-  ];
-
-  const allInstructionsPerLayout = useAllMatchingLayouts(
+  const selectedInstructions = useFirstMatchingLayoutForInstructions(
     api,
     modName,
     fileTree,
-    allInstructionSets,
+    [redscriptBasedirLayout, redscriptCanonLayout, redscriptToplevelLayout],
   );
 
-  const allInstructionsWeProduced = allInstructionsPerLayout.flatMap(
-    (i) => i.instructions,
-  );
-
-  const allInstructions = [
-    ...allInstructionsWeProduced,
-    ...extraCanonArchiveInstructions(api, fileTree).instructions,
-  ];
-
-  if (allInstructions.length < 1) {
+  if (
+    selectedInstructions === NoInstructions.NoMatch ||
+    selectedInstructions === InvalidLayout.Conflict
+  ) {
     return promptToFallbackOrFailOnUnresolvableLayout(
       api,
       InstallerType.Redscript,
@@ -239,8 +189,10 @@ export const installRedscriptMod: VortexWrappedInstallFunc = async (
     );
   }
 
-  api.log(`info`, `${InstallerType.Redscript}: installing`);
-  api.log(`debug`, `${InstallerType.Redscript}: instructions:`, allInstructions);
+  const allInstructions = [
+    ...selectedInstructions.instructions,
+    ...extraCanonArchiveInstructions(api, fileTree).instructions,
+  ];
 
   return Promise.resolve({ instructions: allInstructions });
 };

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -460,7 +460,7 @@ export const AMM_MOD_THEME_REQUIRED_KEYS = [`Text`, `Border`];
 //
 
 export const enum RedscriptLayout {
-  Canon = `.\\r6\\scripts\\[modname]\\*.reds + [any files + subdirs]`,
+  Canon = `.\\r6\\scripts\\[modname]\\[*.reds, any files + subdirs]`,
   Basedir = `.\\r6\\scripts\\*.reds + [any files + subdirs]`,
   Toplevel = `.\\*.reds + [any files + subdirs]`,
 }

--- a/test/unit/mods.example.core.redscript.ts
+++ b/test/unit/mods.example.core.redscript.ts
@@ -1,0 +1,52 @@
+import path from "path";
+import { InstallerType } from "../../src/installers.types";
+import {
+  ExampleSucceedingMod,
+  ExamplesForType,
+  ExampleFailingMod,
+  ExamplePromptInstallableMod,
+} from "./utils.helper";
+
+const CoreRedscriptInstall = new Map<string, ExampleSucceedingMod>(
+  Object.entries({
+    coreRedscriptInstall: {
+      expectedInstallerType: InstallerType.CoreRedscript,
+      inFiles: [
+        path.join("engine/"),
+        path.join("engine/config/"),
+        path.join("engine/config/base/"),
+        path.join("engine/config/base/scripts.ini"),
+        path.join("engine/tools/"),
+        path.join("engine/tools/scc.exe"),
+        path.join("r6/"),
+        path.join("r6/scripts/"),
+        path.join("r6/scripts/redscript.toml"),
+      ].map(path.normalize),
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join("engine/config/base/scripts.ini"),
+          destination: path.join("engine/config/base/scripts.ini"),
+        },
+        {
+          type: "copy",
+          source: path.join("engine/tools/scc.exe"),
+          destination: path.join("engine/tools/scc.exe"),
+        },
+        {
+          type: "copy",
+          source: path.join("r6/scripts/redscript.toml"),
+          destination: path.join("r6/scripts/redscript.toml"),
+        },
+      ],
+    },
+  }),
+);
+
+const examples: ExamplesForType = {
+  AllExpectedSuccesses: CoreRedscriptInstall,
+  AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
+  AllExpectedPromptInstalls: new Map<string, ExamplePromptInstallableMod>(),
+};
+
+export default examples;

--- a/test/unit/mods.example.multitype.ts
+++ b/test/unit/mods.example.multitype.ts
@@ -84,6 +84,30 @@ const ValidTypeCombinations = new Map<string, ExampleSucceedingMod>(
         copiedToSamePath(`${ARCHIVE_PREFIX}/magicgoeshere.archive`),
       ],
     },
+    cetWithRedsInDeepCanonSubdirOnly: {
+      // Mod example: Simple Gameplay Fixes
+      expectedInstallerType: InstallerType.MultiType,
+      inFiles: [
+        ...CET_PREFIXES,
+        path.join(`${CET_PREFIX}/exmod/`),
+        path.join(`${CET_PREFIX}/exmod/Modules/`),
+        path.join(`${CET_PREFIX}/exmod/Modules/morelua.lua`),
+        path.join(`${CET_PREFIX}/exmod/${CET_INIT}`),
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/`),
+        path.join(`${REDS_PREFIX}/canonical/`),
+        path.join(`${REDS_PREFIX}/canonical/butweallowdeeper/`),
+        path.join(`${REDS_PREFIX}/canonical/butweallowdeeper/yay.reds`),
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/magicgoeshere.archive`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${CET_PREFIX}/exmod/${CET_INIT}`),
+        copiedToSamePath(`${CET_PREFIX}/exmod/Modules/morelua.lua`),
+        copiedToSamePath(`${REDS_PREFIX}/canonical/butweallowdeeper/yay.reds`),
+        copiedToSamePath(`${ARCHIVE_PREFIX}/magicgoeshere.archive`),
+      ],
+    },
     multiTypeCetRedscriptRed4ExtCanonical: {
       // Mod example: Furigana
       expectedInstallerType: InstallerType.MultiType,

--- a/test/unit/mods.example.redscript.ts
+++ b/test/unit/mods.example.redscript.ts
@@ -10,6 +10,7 @@ import {
   expectedUserCancelMessageFor,
   ExamplesForType,
   ExampleFailingMod,
+  copiedToSamePath,
 } from "./utils.helper";
 
 const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
@@ -124,6 +125,19 @@ const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
         },
       ],
     },
+    redsWithFirstRedsFilesInDeepSubdir: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/rexmod/`),
+        path.join(`${REDS_PREFIX}/rexmod/dirname/`),
+        path.join(`${REDS_PREFIX}/rexmod/dirname/anotherdirname/`),
+        path.join(`${REDS_PREFIX}/rexmod/dirname/anotherdirname/patch.reds`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${REDS_PREFIX}/rexmod/dirname/anotherdirname/patch.reds`),
+      ],
+    },
   }),
 );
 
@@ -138,25 +152,6 @@ const RedscriptModShouldPromptForInstall = new Map<string, ExamplePromptInstalla
           type: "copy",
           source: path.join(`rexmod/script.reds`),
           destination: path.join(`rexmod/script.reds`),
-        },
-      ],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
-    },
-    redsPatchWithoutCanonical: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/rexmod/`),
-        path.join(`${REDS_PREFIX}/rexmod/dirname/`),
-        path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
-      ],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
         },
       ],
       cancelLabel: InstallChoices.Cancel,

--- a/test/unit/mods.example.redscript.ts
+++ b/test/unit/mods.example.redscript.ts
@@ -1,0 +1,174 @@
+import path from "path";
+import { InstallerType } from "../../src/installers.types";
+import { InstallChoices } from "../../src/ui.dialogs";
+import {
+  ExampleSucceedingMod,
+  REDS_PREFIXES,
+  REDS_PREFIX,
+  FAKE_MOD_NAME,
+  ExamplePromptInstallableMod,
+  expectedUserCancelMessageFor,
+  ExamplesForType,
+  ExampleFailingMod,
+} from "./utils.helper";
+
+const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
+  Object.entries({
+    redsWithBasedirAndCanonicalFilesInstallsToSubdir: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/yay.reds`),
+        path.join(`${REDS_PREFIX}/rexmod/`),
+        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+      ],
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}\\yay.reds`),
+          destination: path.join(`${REDS_PREFIX}\\${FAKE_MOD_NAME}\\yay.reds`),
+        },
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}\\rexmod\\script.reds`),
+          destination: path.join(`${REDS_PREFIX}\\${FAKE_MOD_NAME}\\rexmod\\script.reds`),
+        },
+      ],
+    },
+    redsWithSingleFileCanonical: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/rexmod/`),
+        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+      ],
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+        },
+      ],
+    },
+    redsWithMultipleFilesCanonical: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/rexmod/`),
+        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+        path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
+      ],
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+        },
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
+          destination: path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
+        },
+      ],
+    },
+    redsIncludingNonRedsFilesCanonical: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/rexmod/`),
+        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+        path.join(`${REDS_PREFIX}/rexmod/options.json`),
+      ],
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+        },
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/rexmod/options.json`),
+          destination: path.join(`${REDS_PREFIX}/rexmod/options.json`),
+        },
+      ],
+    },
+    redsSingleScriptTopLevel: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [path.join(`script.reds`)],
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join(`script.reds`),
+          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
+        },
+      ],
+    },
+    redsWithMultipleFilesInRedsBaseDir: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/`),
+        path.join(`${REDS_PREFIX}/script.reds`),
+        path.join(`${REDS_PREFIX}/notascript.reds`),
+      ],
+      outInstructions: [
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/script.reds`),
+          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
+        },
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/notascript.reds`),
+          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/notascript.reds`),
+        },
+      ],
+    },
+  }),
+);
+
+const RedscriptModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
+  Object.entries({
+    redsWithRedsInToplevelSubdirPromptsOnConflictForFallback: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [path.join(`rexmod/script.reds`)],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        {
+          type: "copy",
+          source: path.join(`rexmod/script.reds`),
+          destination: path.join(`rexmod/script.reds`),
+        },
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
+    },
+    redsPatchWithoutCanonical: {
+      expectedInstallerType: InstallerType.Redscript,
+      inFiles: [
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/rexmod/`),
+        path.join(`${REDS_PREFIX}/rexmod/dirname/`),
+        path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
+      ],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        {
+          type: "copy",
+          source: path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
+          destination: path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
+        },
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
+    },
+  }),
+);
+
+const examples: ExamplesForType = {
+  AllExpectedSuccesses: RedscriptModShouldSucceed,
+  AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
+  AllExpectedPromptInstalls: RedscriptModShouldPromptForInstall,
+};
+
+export default examples;

--- a/test/unit/mods.example.redscript.ts
+++ b/test/unit/mods.example.redscript.ts
@@ -11,6 +11,7 @@ import {
   ExamplesForType,
   ExampleFailingMod,
   copiedToSamePath,
+  movedFromTo,
 } from "./utils.helper";
 
 const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
@@ -24,16 +25,14 @@ const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
         path.join(`${REDS_PREFIX}/rexmod/script.reds`),
       ],
       outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}\\yay.reds`),
-          destination: path.join(`${REDS_PREFIX}\\${FAKE_MOD_NAME}\\yay.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}\\rexmod\\script.reds`),
-          destination: path.join(`${REDS_PREFIX}\\${FAKE_MOD_NAME}\\rexmod\\script.reds`),
-        },
+        movedFromTo(
+          `${REDS_PREFIX}/yay.reds`,
+          `${REDS_PREFIX}/${FAKE_MOD_NAME}/yay.reds`,
+        ),
+        movedFromTo(
+          `${REDS_PREFIX}/rexmod/script.reds`,
+          `${REDS_PREFIX}/${FAKE_MOD_NAME}/rexmod/script.reds`,
+        ),
       ],
     },
     redsWithSingleFileCanonical: {
@@ -43,13 +42,7 @@ const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
         path.join(`${REDS_PREFIX}/rexmod/`),
         path.join(`${REDS_PREFIX}/rexmod/script.reds`),
       ],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        },
-      ],
+      outInstructions: [copiedToSamePath(`${REDS_PREFIX}/rexmod/script.reds`)],
     },
     redsWithMultipleFilesCanonical: {
       expectedInstallerType: InstallerType.Redscript,
@@ -60,16 +53,8 @@ const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
         path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
       ],
       outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
-        },
+        copiedToSamePath(`${REDS_PREFIX}/rexmod/script.reds`),
+        copiedToSamePath(`${REDS_PREFIX}/rexmod/notascript.reds`),
       ],
     },
     redsIncludingNonRedsFilesCanonical: {
@@ -81,27 +66,15 @@ const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
         path.join(`${REDS_PREFIX}/rexmod/options.json`),
       ],
       outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/options.json`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/options.json`),
-        },
+        copiedToSamePath(`${REDS_PREFIX}/rexmod/script.reds`),
+        copiedToSamePath(`${REDS_PREFIX}/rexmod/options.json`),
       ],
     },
     redsSingleScriptTopLevel: {
       expectedInstallerType: InstallerType.Redscript,
       inFiles: [path.join(`script.reds`)],
       outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`script.reds`),
-          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
-        },
+        movedFromTo(`script.reds`, `${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
       ],
     },
     redsWithMultipleFilesInRedsBaseDir: {
@@ -113,16 +86,14 @@ const RedscriptModShouldSucceed = new Map<string, ExampleSucceedingMod>(
         path.join(`${REDS_PREFIX}/notascript.reds`),
       ],
       outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/notascript.reds`),
-          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/notascript.reds`),
-        },
+        movedFromTo(
+          `${REDS_PREFIX}/script.reds`,
+          `${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`,
+        ),
+        movedFromTo(
+          `${REDS_PREFIX}/notascript.reds`,
+          `${REDS_PREFIX}/${FAKE_MOD_NAME}/notascript.reds`,
+        ),
       ],
     },
     redsWithFirstRedsFilesInDeepSubdir: {
@@ -147,13 +118,7 @@ const RedscriptModShouldPromptForInstall = new Map<string, ExamplePromptInstalla
       expectedInstallerType: InstallerType.Redscript,
       inFiles: [path.join(`rexmod/script.reds`)],
       proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        {
-          type: "copy",
-          source: path.join(`rexmod/script.reds`),
-          destination: path.join(`rexmod/script.reds`),
-        },
-      ],
+      proceedOutInstructions: [copiedToSamePath(`rexmod/script.reds`)],
       cancelLabel: InstallChoices.Cancel,
       cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
     },

--- a/test/unit/mods.example.ts
+++ b/test/unit/mods.example.ts
@@ -134,42 +134,6 @@ const CoreCetInstall = new Map<string, ExampleSucceedingMod>(
   }),
 );
 
-const CoreRedscriptInstall = new Map<string, ExampleSucceedingMod>(
-  Object.entries({
-    coreRedscriptInstall: {
-      expectedInstallerType: InstallerType.CoreRedscript,
-      inFiles: [
-        path.join("engine/"),
-        path.join("engine/config/"),
-        path.join("engine/config/base/"),
-        path.join("engine/config/base/scripts.ini"),
-        path.join("engine/tools/"),
-        path.join("engine/tools/scc.exe"),
-        path.join("r6/"),
-        path.join("r6/scripts/"),
-        path.join("r6/scripts/redscript.toml"),
-      ].map(path.normalize),
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join("engine/config/base/scripts.ini"),
-          destination: path.join("engine/config/base/scripts.ini"),
-        },
-        {
-          type: "copy",
-          source: path.join("engine/tools/scc.exe"),
-          destination: path.join("engine/tools/scc.exe"),
-        },
-        {
-          type: "copy",
-          source: path.join("r6/scripts/redscript.toml"),
-          destination: path.join("r6/scripts/redscript.toml"),
-        },
-      ],
-    },
-  }),
-);
-
 const CoreTweakXLInstall = new Map<string, ExampleSucceedingMod>(
   Object.entries({
     coreTweakXLInstallCanon: {
@@ -693,159 +657,6 @@ const CetModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod
       ],
       cancelLabel: InstallChoices.Cancel,
       cancelErrorMessage: `Fallback Installer: user chose to cancel installation`,
-    },
-  }),
-);
-
-const RedscriptMod = new Map<string, ExampleSucceedingMod>(
-  Object.entries({
-    redsWithBasedirAndCanonicalFilesInstallsToSubdir: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/yay.reds`),
-        path.join(`${REDS_PREFIX}/rexmod/`),
-        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-      ],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}\\yay.reds`),
-          destination: path.join(`${REDS_PREFIX}\\${FAKE_MOD_NAME}\\yay.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}\\rexmod\\script.reds`),
-          destination: path.join(`${REDS_PREFIX}\\${FAKE_MOD_NAME}\\rexmod\\script.reds`),
-        },
-      ],
-    },
-    redsWithSingleFileCanonical: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/rexmod/`),
-        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-      ],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        },
-      ],
-    },
-    redsWithMultipleFilesCanonical: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/rexmod/`),
-        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
-      ],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/notascript.reds`),
-        },
-      ],
-    },
-    redsIncludingNonRedsFilesCanonical: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/rexmod/`),
-        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        path.join(`${REDS_PREFIX}/rexmod/options.json`),
-      ],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/script.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/options.json`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/options.json`),
-        },
-      ],
-    },
-    redsSingleScriptTopLevel: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [path.join(`script.reds`)],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`script.reds`),
-          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
-        },
-      ],
-    },
-    redsWithMultipleFilesInRedsBaseDir: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/`),
-        path.join(`${REDS_PREFIX}/script.reds`),
-        path.join(`${REDS_PREFIX}/notascript.reds`),
-      ],
-      outInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/script.reds`),
-          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/script.reds`),
-        },
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/notascript.reds`),
-          destination: path.join(`${REDS_PREFIX}/${FAKE_MOD_NAME}/notascript.reds`),
-        },
-      ],
-    },
-  }),
-);
-
-const RedscriptModShouldPromptForInstall = new Map<string, ExamplePromptInstallableMod>(
-  Object.entries({
-    redsWithRedsInToplevelSubdirPromptsOnConflictForFallback: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [path.join(`rexmod/script.reds`)],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        {
-          type: "copy",
-          source: path.join(`rexmod/script.reds`),
-          destination: path.join(`rexmod/script.reds`),
-        },
-      ],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
-    },
-    redsPatchWithoutCanonical: {
-      expectedInstallerType: InstallerType.Redscript,
-      inFiles: [
-        ...REDS_PREFIXES,
-        path.join(`${REDS_PREFIX}/rexmod/`),
-        path.join(`${REDS_PREFIX}/rexmod/dirname/`),
-        path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
-      ],
-      proceedLabel: InstallChoices.Proceed,
-      proceedOutInstructions: [
-        {
-          type: "copy",
-          source: path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
-          destination: path.join(`${REDS_PREFIX}/rexmod/dirname/patch.reds`),
-        },
-      ],
-      cancelLabel: InstallChoices.Cancel,
-      cancelErrorMessage: expectedUserCancelMessageFor(InstallerType.Redscript),
     },
   }),
 );
@@ -1781,9 +1592,11 @@ const GiftwrappedModsFixable = new Map<string, ExampleSucceedingMod>(
 //
 
 import AmmCore from "./mods.example.core.amm";
-import AmmMod from "./mods.example.amm";
+import RedscriptCore from "./mods.example.core.redscript";
 import MultiTypeMod from "./mods.example.multitype";
 import JsonMod from "./mods.example.config.json";
+import AmmMod from "./mods.example.amm";
+import RedscriptMod from "./mods.example.redscript";
 
 import ExtraFiles from "./mods.example.special.extrafiles";
 
@@ -1791,7 +1604,7 @@ export const AllExpectedSuccesses = new Map<string, ExampleModCategory>(
   Object.entries({
     CoreAmmInstallShouldSucceed: AmmCore.AllExpectedSuccesses,
     CoreCetInstall,
-    CoreRedscriptInstall,
+    CoreRedscriptInstallShouldSucceed: RedscriptCore.AllExpectedSuccesses,
     CoreRed4ExtInstall,
     CoreCsvMergeInstall,
     CoreWolvenkitCliInstall,
@@ -1804,7 +1617,7 @@ export const AllExpectedSuccesses = new Map<string, ExampleModCategory>(
     AsiMod,
     AmmModInstallShouldSucceed: AmmMod.AllExpectedSuccesses,
     CetMod,
-    RedscriptMod,
+    RedscriptModInstallShouldSucceed: RedscriptMod.AllExpectedSuccesses,
     Red4ExtMod,
     IniMod,
     ArchiveOnly: ArchiveMod,
@@ -1838,7 +1651,7 @@ export const AllExpectedInstallPromptables = new Map<
     ConfigJsonModShouldPromptForInstall: JsonMod.AllExpectedPromptInstalls,
     AmmModShouldPromptForInstall: AmmMod.AllExpectedPromptInstalls,
     CetModShouldPromptForInstall,
-    RedscriptModShouldPromptForInstall,
+    RedscriptModShouldPromptForInstall: RedscriptMod.AllExpectedPromptInstalls,
     Red4ExtModShouldPromptForInstall,
     TweakXLModShouldPromptForInstall,
     ArchiveOnlyModShouldPromptForInstall,


### PR DESCRIPTION
Unlike we previously specced, the topmost `.reds` doesn't need to be max 1 subdir. So let's fix that..

- [x] Confirmed w/ Redscript team
- [x] Remove logic relating to "patching" redscript mods if any
- [x] Fix for Redscript.Canon
- [x] Fix for MultiType

Closes #157 