### PR TITLE
Update GOG REDmod URL to open the store page in GOG Galaxy

### DIFF
--- a/src/redmodding.ts
+++ b/src/redmodding.ts
@@ -39,7 +39,7 @@ const getREDmodetails = (id: string): IREDmodDetails => {
     gog: {
       name: `GOG`,
       url: `https://www.gog.com/en/game/cyberpunk_2077_redmod`,
-      openCommand: (): Promise<void> => VortexUtil.opn(`goggalaxy://openGameView/1597316373`),
+      openCommand: (): Promise<void> => VortexUtil.opn(`goggalaxy://openStoreUrl/embed.gog.com/game/cyberpunk_2077_redmod`),
     },
   };
 

--- a/src/ui.dialogs.ts
+++ b/src/ui.dialogs.ts
@@ -64,7 +64,7 @@ export const promptUserInstallREDmodDLC = async (
   const redmodInstallExplanation = `
   The 1.6 update for Cyberpunk 2077 included an optional DLC called REDmod. 
   This DLC allows the game to load modded content created with the REDmod toolkit.
-  Vortex has detected that the REDmod DLC is installed on your system.
+  Vortex has detected that the REDmod DLC is not installed on your system.
   You can get the DLC for free${redModDetails.name ? ` from ${redModDetails.name}` : null} using the button below.`;
 
   return api.showDialog(


### PR DESCRIPTION
Special thanks to Rafał on GOG's Product Team for providing the information.

Also fixed a typo in the REDmod message. 