### PR TITLE
✨ Reject REDmods With Any Invalid-Looking Moddirs

### DIFF
--- a/test/unit/mods.example.redmod.ts
+++ b/test/unit/mods.example.redmod.ts
@@ -109,9 +109,30 @@ const REDmodSucceeds = new Map<string, ExampleSucceedingMod>([
   ],
 ]);
 
+const REDmodDirectFailures = new Map<string, ExampleFailingMod>([
+  [
+    `Canonical REDmod with one or more of the moddirs missing a required file`,
+    {
+      expectedInstallerType: InstallerType.REDmod,
+      inFiles: [
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModGood/`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModGood/info.json`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModGood/archives/`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModGood/archives/cool_stuff.archive`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModBad/`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModBad/archives/`),
+        path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModBad/archives/wouldbesupercool.archive`),
+      ],
+      failure: `Missing Required REDmod Files!`,
+      errorDialogTitle: `Missing Required REDmod Files!`,
+    },
+  ],
+]);
+
 const examples: ExamplesForType = {
   AllExpectedSuccesses: REDmodSucceeds,
-  AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
+  AllExpectedDirectFailures: REDmodDirectFailures,
   AllExpectedPromptInstalls: new Map<string, ExamplePromptInstallableMod>(),
 };
 

--- a/test/unit/mods.example.redmod.ts
+++ b/test/unit/mods.example.redmod.ts
@@ -124,8 +124,8 @@ const REDmodDirectFailures = new Map<string, ExampleFailingMod>([
         path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModBad/archives/`),
         path.join(`${REDMOD_CANONICAL_BASEDIR}/myRedModBad/archives/wouldbesupercool.archive`),
       ],
-      failure: `Missing Required REDmod Files!`,
-      errorDialogTitle: `Missing Required REDmod Files!`,
+      failure: `Didn't Find Expected REDmod Installation!`,
+      errorDialogTitle: `Didn't Find Expected REDmod Installation!`,
     },
   ],
 ]);


### PR DESCRIPTION
All REDmod submods (i.e. `mods/mod1/` + `mods/mod2`) must be valid (i.e. have an info.json for now)