### PR TITLE
✨ Archive -> REDmod Autoconversion (Standalone + MultiType)

### DIFF
--- a/src/installer.multitype.ts
+++ b/src/installer.multitype.ts
@@ -5,7 +5,7 @@ import {
 } from "./filetree";
 import {
   detectExtraArchiveLayouts,
-  extraCanonArchiveInstructions,
+  extraCanonArchiveInstructionsForMultiType,
 } from "./installer.archive";
 import {
   detectCetCanonLayout,
@@ -188,7 +188,7 @@ export const installMultiTypeMod: V2077InstallFunc = async (
     (result) => result.instructions,
   );
 
-  const archiveInstructions = extraCanonArchiveInstructions(api, fileTree);
+  const archiveInstructions = extraCanonArchiveInstructionsForMultiType(api, fileTree, modInfo, features);
   const tweakXLInstructions = tweakXLAllowedInMultiInstructions(api, fileTree);
 
   const redscriptInstructions = redscriptAllowedInMultiInstructions(

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -120,9 +120,8 @@ export const enum ExtraFilesLayout {
 // Giftwrapped
 
 export const enum GiftwrapLayout {
-  ExtraToplevelDir = `Either
+  ExtraToplevelDir = `
                       | - .\\[dirname]\\[any dir that should be toplevel: archive, bin, engine, r6, red4ext]
-                      | - .\\[dirname]\\mods\\[modname]\\info.json {name: modname...} + [any REDmod subdirs]
                     `,
 }
 
@@ -1073,6 +1072,10 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
     - \`${REDmodLayout.Canon}\` (Canonical)
     - \`${REDmodLayout.Named}\` (Can be fixed to canonical)
     - \`${REDmodLayout.Toplevel}\` (Can be fixed to canonical)
+
+    Additionally
+
+    - \`${REDmodTransformedLayout.Archive}\`
     `,
   ],
   [

--- a/src/installers.utils.ts
+++ b/src/installers.utils.ts
@@ -12,4 +12,5 @@ export const exhaustiveMatchFailure = (_: never): never => {
   throw new Error(`Type guard failed`);
 };
 
+export const s = (thing: unknown): string => JSON.stringify(thing, null, 2);
 export const S = (thing: unknown): string => JSON.stringify(thing);

--- a/src/ui.notifications.ts
+++ b/src/ui.notifications.ts
@@ -20,6 +20,7 @@ export const enum InfoNotification {
   InstallerExtraFilesMoved = `V2077-notify-info-installer-extrafilesmoved`,
   CyberCatRestartRequired = `V2077-notify-info-restart-required`,
   REDmodArchiveAutoconverted = `V2077-notify-info-redmod-archive-autoconverted`,
+  REDmodArchiveNOTautoconverted = `V2077-notify-info-redmod-archive-NOT-autoconverted`,
 }
 
 //
@@ -49,9 +50,18 @@ const InfoNotificationsUnsafeMap = new Map<InfoNotification, Notification>([
     InfoNotification.REDmodArchiveAutoconverted,
     {
       id: InfoNotification.REDmodArchiveAutoconverted,
-      type: `info`,
+      type: `success`,
       title: `Mod Autoconverted to REDmod`,
       message: `The mod was automatically converted and will be installed as a REDmod`,
+    },
+  ],
+  [
+    InfoNotification.REDmodArchiveNOTautoconverted,
+    {
+      id: InfoNotification.REDmodArchiveNOTautoconverted,
+      type: `info`,
+      title: `Mod NOT Autoconverted to REDmod`,
+      message: `The mod was NOT automatically converted and will be installed as a regular mod`,
     },
   ],
 ]);

--- a/test/unit/mods.example.archive.ts
+++ b/test/unit/mods.example.archive.ts
@@ -1,19 +1,7 @@
 import path from "path";
-import {
-  CurrentFeatureSet,
-  Feature,
-  Features,
-} from "../../src/features";
-import {
-  ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX,
-  REDMOD_AUTOCONVERTED_NAME_TAG,
-  REDMOD_ARCHIVES_DIRNAME,
-  REDMOD_BASEDIR,
-  REDMOD_INFO_FILENAME,
-} from "../../src/installers.layouts";
+import { ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX } from "../../src/installers.layouts";
 import { InstallerType } from "../../src/installers.types";
 import { InstallChoices } from "../../src/ui.dialogs";
-import { InfoNotification } from "../../src/ui.notifications";
 import {
   ExampleSucceedingMod,
   ARCHIVE_PREFIXES,
@@ -29,9 +17,6 @@ import {
   ExamplesForType,
   mergeOrFailOnConflict,
   ExampleFailingMod,
-  movedFromTo,
-  generatedFile,
-  FAKE_MOD_INFO,
 } from "./utils.helper";
 
 const ArchiveModSucceeds = new Map<string, ExampleSucceedingMod>(
@@ -399,54 +384,10 @@ const ValidExtraArchivesWithTypeSucceeds = new Map<string, ExampleSucceedingMod>
   }),
 );
 
-//
-// REDmodding
-//
-
-const FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES: Features = {
-  ...CurrentFeatureSet,
-  REDmodAutoconvertArchives: Feature.Enabled,
-};
-
-const AUTOCONVERT_MOD_NAME = `${FAKE_MOD_INFO.name} ${REDMOD_AUTOCONVERTED_NAME_TAG}`;
-const AUTOCONVERT_MOD_DIR = AUTOCONVERT_MOD_NAME;
-const AUTOCONVERT_MOD_VERSION = `${FAKE_MOD_INFO.version.v}+V2077RED`;
-
-const REDMOD_FAKE_INFO_JSON = JSON.stringify({
-  name: AUTOCONVERT_MOD_NAME,
-  version: AUTOCONVERT_MOD_VERSION,
-});
-
-const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod>([
-  [
-    `Canonical with single archive migrated to REDmod`,
-    {
-      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
-      expectedInstallerType: InstallerType.Archive,
-      inFiles: [
-        ...ARCHIVE_PREFIXES,
-        path.join(`${ARCHIVE_PREFIX}/first.archive`),
-      ],
-      outInstructions: [
-        movedFromTo(
-          path.join(`${ARCHIVE_PREFIX}/first.archive`),
-          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
-        ),
-        generatedFile(
-          REDMOD_FAKE_INFO_JSON,
-          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
-        ),
-      ],
-      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
-    },
-  ],
-]);
-
 const examples: ExamplesForType = {
   AllExpectedSuccesses: mergeOrFailOnConflict(
     ArchiveModSucceeds,
     ValidExtraArchivesWithTypeSucceeds,
-    ArchiveModToREDmodMigrationSucceeds,
   ),
   AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
   AllExpectedPromptInstalls: mergeOrFailOnConflict(ArchiveOnlyModShouldPromptForInstall),

--- a/test/unit/mods.example.redmod.autoconversion.ts
+++ b/test/unit/mods.example.redmod.autoconversion.ts
@@ -1,0 +1,266 @@
+import path from "path";
+import {
+  Features,
+  CurrentFeatureSet,
+  Feature,
+} from "../../src/features";
+import {
+  REDMOD_AUTOCONVERTED_NAME_TAG,
+  REDMOD_BASEDIR,
+  REDMOD_ARCHIVES_DIRNAME,
+  REDMOD_INFO_FILENAME,
+  ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX,
+  ARCHIVE_MOD_CANONICAL_PREFIX,
+} from "../../src/installers.layouts";
+import { InstallerType } from "../../src/installers.types";
+import { InfoNotification } from "../../src/ui.notifications";
+import {
+  FAKE_MOD_INFO,
+  ExampleSucceedingMod,
+  ARCHIVE_PREFIXES,
+  ARCHIVE_PREFIX,
+  movedFromTo,
+  generatedFile,
+  GIFTWRAP_PREFIX,
+  copiedToSamePath,
+  ExamplesForType,
+  mergeOrFailOnConflict,
+  ExampleFailingMod,
+  ExamplePromptInstallableMod,
+  CET_INIT,
+  CET_PREFIX,
+  CET_PREFIXES,
+  FAKE_MOD_NAME,
+  RED4EXT_PREFIX,
+  RED4EXT_PREFIXES,
+  REDS_PREFIX,
+  REDS_PREFIXES,
+} from "./utils.helper";
+
+
+const FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES: Features = {
+  ...CurrentFeatureSet,
+  REDmodAutoconvertArchives: Feature.Enabled,
+};
+
+const AUTOCONVERT_MOD_NAME = `${FAKE_MOD_INFO.name} ${REDMOD_AUTOCONVERTED_NAME_TAG}`;
+const AUTOCONVERT_MOD_DIR = AUTOCONVERT_MOD_NAME;
+const AUTOCONVERT_MOD_VERSION = `${FAKE_MOD_INFO.version.v}+V2077RED`;
+
+const REDMOD_FAKE_INFO_JSON = JSON.stringify({
+  name: AUTOCONVERT_MOD_NAME,
+  version: AUTOCONVERT_MOD_VERSION,
+});
+
+const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod>([
+  [
+    `Canonical with single archive migrated to REDmod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+  [
+    `Heritage with single archive migrated to REDmod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX}/first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${ARCHIVE_MOD_TRADITIONAL_WRONG_PREFIX}/first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+  [
+    `toplevel archive mod with single archive migrated to REDmod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        path.join(`first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+  [
+    `giftwrapped archive mod with single archive migrated to REDmod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        path.join(`${GIFTWRAP_PREFIX}\\${ARCHIVE_MOD_CANONICAL_PREFIX}\\first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${GIFTWRAP_PREFIX}\\${ARCHIVE_MOD_CANONICAL_PREFIX}\\first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+  [
+    `Multiple archives warn about manual intervention but install as autoconverted REDmod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/first.archive`),
+        path.join(`${ARCHIVE_PREFIX}/second.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/second.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\second.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoDialogTitle: `Mod Installed But May Need Manual Adjustment!`,
+    },
+  ],
+  [
+    `Subfoldered archives warn about manual intervention but install as autoconverted REDmod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/some-dir/first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/some-dir/first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\some-dir\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+]);
+
+
+const MultiTypeWithArchiveREDmodAutoconversion = new Map<string, ExampleSucceedingMod>([
+  [
+    `MultiType with Archive converts Archive to REDmod when autoconversion enabled`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.MultiType,
+      inFiles: [
+        ...CET_PREFIXES,
+        path.join(`${CET_PREFIX}/exmod/`),
+        path.join(`${CET_PREFIX}/exmod/Modules/`),
+        path.join(`${CET_PREFIX}/exmod/Modules/morelua.lua`),
+        path.join(`${CET_PREFIX}/exmod/${CET_INIT}`),
+        ...REDS_PREFIXES,
+        path.join(`${REDS_PREFIX}/rexmod/script.reds`),
+        ...RED4EXT_PREFIXES,
+        path.join(`${RED4EXT_PREFIX}/script.dll`),
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/magicgoeshere.archive`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${CET_PREFIX}/exmod/${CET_INIT}`),
+        copiedToSamePath(`${CET_PREFIX}/exmod/Modules/morelua.lua`),
+        copiedToSamePath(`${REDS_PREFIX}/rexmod/script.reds`),
+        {
+          type: `copy`,
+          source: path.join(`${RED4EXT_PREFIX}/script.dll`),
+          destination: path.join(`${RED4EXT_PREFIX}/${FAKE_MOD_NAME}/script.dll`),
+        },
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/magicgoeshere.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_ARCHIVES_DIRNAME}\\magicgoeshere.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
+        ),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+]);
+
+const ArchiveModToREDmodMigrationCantBeDoneButWeFallbackToOldstyle = new Map<string, ExampleSucceedingMod>([
+  [
+    `XL can't be autoconverted fully so it is installed as a regular Archive mod`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/first.archive`),
+        path.join(`${ARCHIVE_PREFIX}/first.archive.xl`),
+      ],
+      outInstructions: [
+        copiedToSamePath(`${ARCHIVE_PREFIX}/first.archive`),
+        copiedToSamePath(`${ARCHIVE_PREFIX}/first.archive.xl`),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveNOTautoconverted,
+    },
+  ],
+]);
+
+const examples: ExamplesForType = {
+  AllExpectedSuccesses: mergeOrFailOnConflict(
+    ArchiveModToREDmodMigrationSucceeds,
+    MultiTypeWithArchiveREDmodAutoconversion,
+    ArchiveModToREDmodMigrationCantBeDoneButWeFallbackToOldstyle,
+  ),
+  AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
+  AllExpectedPromptInstalls: new Map<string, ExamplePromptInstallableMod>(),
+};
+
+export default examples;

--- a/test/unit/mods.example.redmod.autoconversion.ts
+++ b/test/unit/mods.example.redmod.autoconversion.ts
@@ -164,6 +164,7 @@ const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod
         ),
       ],
       infoDialogTitle: `Mod Installed But May Need Manual Adjustment!`,
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
     },
   ],
   [
@@ -185,6 +186,7 @@ const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod
           path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_DIR}\\${REDMOD_INFO_FILENAME}`),
         ),
       ],
+      infoDialogTitle: `Mod Installed But May Need Manual Adjustment!`,
       infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
     },
   ],

--- a/test/unit/utils.helper.ts
+++ b/test/unit/utils.helper.ts
@@ -263,7 +263,7 @@ export const ARCHIVE_PREFIXES = pathHierarchyFor(ARCHIVE_PREFIX);
 export const ASI_PREFIX = ASI_MOD_PATH;
 export const ASI_PREFIXES = pathHierarchyFor(ASI_PREFIX);
 
-export const GIFTWRAP_PREFIX = `some-dirname`;
+export const GIFTWRAP_PREFIX = `giftwrapper-dirname`;
 
 export const CET_GIFTWRAPS = pathHierarchyFor(`${GIFTWRAP_PREFIX}\\${CET_PREFIX}`);
 export const REDS_GIFTWRAPS = pathHierarchyFor(`${GIFTWRAP_PREFIX}\\${REDS_PREFIX}`);


### PR DESCRIPTION
Most Archive mods can be autoconverted, including those in MultiType. Exceptions:

- ArchiveXL aren't converted (#258)
- Some sprinkled-around 'extra archives' that are not handled by MultiType (#259)

Additionally as already implemented, MultiType can't contain both Archives and REDmods, that will continue to fail as before.

```
  redmod.autoconversion mods                                                             
      √ produce the expected instructions when Canonical with single archive migrated to REDmod (8 ms)                                                                                
      √ produce the expected instructions when Heritage with single archive migrated to REDmod (7 ms)                                                                                 
      √ produce the expected instructions when toplevel archive mod with single archive migrated to REDmod (7 ms)                                                                     
      √ produce the expected instructions when giftwrapped archive mod with single archive migrated to REDmod (7 ms)                                                                  
      √ produce the expected instructions when Multiple archives warn about manual intervention but install as autoconverted REDmod (8 ms)                                            
      √ produce the expected instructions when Subfoldered archives warn about manual intervention but install as autoconverted REDmod (7 ms)                                         
      √ produce the expected instructions when MultiType with Archive converts Archive to REDmod when autoconversion enabled (9 ms)                                                   
      √ produce the expected instructions when XL can't be autoconverted fully so it is installed as a regular Archive mod (7 ms)    ```