### PR TITLE
🐛 Prevent Unauthorized Hook Access from Crashing

### DIFF
--- a/src/index.metadata.ts
+++ b/src/index.metadata.ts
@@ -1,6 +1,3 @@
-import {
-  VortexExtensionApi,
-} from "./vortex-wrapper";
 
 // Nexus Mods domain for the game. e.g. nexusmods.com/cyberpunk2077
 export const GAME_ID = `cyberpunk2077`;
@@ -29,11 +26,3 @@ export const V2077_GENERATED_MOD_VERSION_PRERELEASE = EXTENSION_NAME_INTERNAL;
 export const VORTEX_STORE_PATHS = {
   settings: [`settings`, `v2077`],
 };
-
-export const isSupported = (gameMode: string): boolean => (gameMode === GAME_ID);
-
-
-// Let it crash. We can't function if this doesn't work.
-export const gameDirPath =
-  (api: VortexExtensionApi): string =>
-    api.store.getState().settings.gameMode.discovered[GAME_ID].path;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ import {
   GAME_EXE_RELATIVE_PATH,
   GAME_ID,
   GOGAPP_ID,
-  isSupported,
   STEAMAPP_ID,
   V2077_DIR,
   VORTEX_STORE_PATHS,
@@ -85,6 +84,9 @@ import * as ExternalTools from "./tools.external";
 import {
   ToolStartHook,
 } from "./tools.types";
+import {
+  isSupported,
+} from "./state.functions";
 
 
 //

--- a/src/state.functions.ts
+++ b/src/state.functions.ts
@@ -1,0 +1,47 @@
+import {
+  chain as chainE,
+  Either,
+  fromOption as fromOptionE,
+  left,
+  right,
+  tryCatch as tryCatchE,
+} from "fp-ts/lib/Either";
+import {
+  flow,
+} from "fp-ts/lib/function";
+import {
+  Option,
+  fromNullable,
+} from "fp-ts/lib/Option";
+import {
+  isEmpty as isEmptyS,
+  isString,
+} from "fp-ts/lib/string";
+import {
+  GAME_ID,
+} from "./index.metadata";
+import {
+  constant,
+} from "./util.functions";
+import {
+  VortexExtensionApi,
+} from "./vortex-wrapper";
+
+export const isSupported = (gameMode: string): boolean => (gameMode === GAME_ID);
+
+
+export const maybeGameDirPath =
+  (api: VortexExtensionApi): Either<Error, Option<string> > =>
+    tryCatchE(
+      (): Option<string> => fromNullable(api.store.getState().settings.gameMode.discovered[GAME_ID].path),
+      (err) => new Error(`Unable to retrieve game dir path: ${err}`),
+    );
+
+export const gameDirPath = flow(
+  maybeGameDirPath,
+  chainE(fromOptionE(constant(new Error(`Game dir path must be set`)))),
+  chainE((maybePath) =>
+    (isString(maybePath) && !isEmptyS(maybePath)
+      ? right(maybePath)
+      : left(new Error(`Game dir path must not be empty`)))),
+);


### PR DESCRIPTION
There's an edge case where having the extension installed but the game itself missing from discovery will lead to a crash in the original `gameDirPath` check. This should prevent crashing and will instead safely bail out.

We really need to find a way to test these.

Closes #288 