### PR TITLE
💫 `-force` REDdeploy as a temporary workaround

### DIFF
--- a/src/load_order.ts
+++ b/src/load_order.ts
@@ -486,6 +486,7 @@ export const loadOrderToREDdeployRunParameters = (
 
   const redModDeployParametersToCreateNewManifest = [
     `deploy`,
+    `-force`, // TODO: Required until https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/297
     `-root=`,
     `"${gameDirPath}"`,
     `-rttiSchemaFile=`,

--- a/test/unit/loadorder.test.ts
+++ b/test/unit/loadorder.test.ts
@@ -97,6 +97,7 @@ describe(`Load Order`, () => {
         executable: `${FAKE_GAMEDIR_PATH}\\${REDdeployManual.executable()}`,
         args: [
           `deploy`,
+          `-force`,
           `-root=`,
           `"${FAKE_GAMEDIR_PATH}"`,
           `-rttiSchemaFile=`,
@@ -133,6 +134,7 @@ describe(`Load Order`, () => {
         executable: `${FAKE_GAMEDIR_PATH}\\${REDdeployManual.executable()}`,
         args: [
           `deploy`,
+          `-force`,
           `-root=`,
           `"${FAKE_GAMEDIR_PATH}"`,
           `-rttiSchemaFile=`,


### PR DESCRIPTION
Until #297 fixed upstream because of #296. We need this to generate a new mods.json on *order* changes, not just enables/disables.