### PR TITLE
Fix an exception when the user isn't managing the game via a game store

### DIFF
--- a/src/redmodding.ts
+++ b/src/redmodding.ts
@@ -131,7 +131,7 @@ const prepareForModdingWithREDmodding = async (
   }
 
   const gameStoreIfInstalledThroughStore =
-    await VortexUtil.GameStoreHelper.findByAppId([GOGAPP_ID, STEAMAPP_ID, EPICAPP_ID]);
+    await VortexUtil.GameStoreHelper.findByAppId([GOGAPP_ID, STEAMAPP_ID, EPICAPP_ID]).catch(() => undefined);
 
   if (gameStoreIfInstalledThroughStore?.gamePath !== discovery.path) {
     vortexApi.log(`warn`, `Cyberpunk discovery doesn't match auto-detected path`, { discovery: discovery.path, autoDetect: gameStoreIfInstalledThroughStore.path });


### PR DESCRIPTION
GameStoreHelper.findByAppId() throw an exception when there are no results.