### PR TITLE
🐛 Run REDdeploy as Direct Invocation Instead of Shell

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -46,6 +46,19 @@ export const IfFeatureEnabled = <T>(featureState: FeatureState, then: Dynamic<T>
 export const enum StaticFeature {
   REDmodding = `v2077_feature_redmodding`,
   REDmodLoadOrder = `v2077_feature_redmod_load_order`,
+  // TODO: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/313
+  //
+  //       Maybe we can do something better here? This will only increase
+  //       the limit from 8192 to 32k anyway, but that does give us headroom.
+  //       Just kind of a worse UX until and if we come up with a spinner-like.
+  //
+  //       And error handling might be trickier.
+  //
+  // TODO: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/316
+  //
+  //       Turn this into a DynamicFeature once we have a solid way to
+  //       directly derive the settings from it #278
+  ExePreferDirectSpawnWithoutShell = `v2077_feature_exe_prefer_direct_spawn_without_shell`,
 }
 
 // Need to be underscored since it isn't always just a string... thanks react...
@@ -71,16 +84,18 @@ export type FeatureSet = VersionedStaticFeatureSet & DynamicFeatureSet;
 // ...Through these records
 
 export const BaselineFeatureSetForTests: FeatureSet = {
-  fromVersion: `0.9.0`,
+  fromVersion: `0.9.3`,
   REDmodding: FeatureState.Disabled,
   REDmodLoadOrder: FeatureState.Disabled,
+  ExePreferDirectSpawnWithoutShell: FeatureState.Disabled,
   REDmodAutoconvertArchives: () => FeatureState.Disabled,
 };
 
 export const StaticFeaturesForStartup: VersionedStaticFeatureSet = {
-  fromVersion: `0.9.0`,
+  fromVersion: `0.9.3`,
   REDmodding: FeatureState.Enabled,
   REDmodLoadOrder: FeatureState.Enabled,
+  ExePreferDirectSpawnWithoutShell: FeatureState.Enabled,
 };
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,9 +276,12 @@ const main = (vortexExt: VortexExtensionContext): boolean => {
         // toggleableEntries: true,
         //
         usageInstructions: loadOrderUsageInstructionsForVortexGui,
-        validate: wrapValidate(vortexExt, vortexApiLib, internalLoadOrderer),
-        deserializeLoadOrder: wrapDeserialize(vortexExt, vortexApiLib, internalLoadOrderer),
-        serializeLoadOrder: wrapSerialize(vortexExt, vortexApiLib, internalLoadOrderer),
+        validate:
+          wrapValidate(vortexExt, vortexApiLib, fullFeatureSetAvailablePostStartup, internalLoadOrderer),
+        deserializeLoadOrder:
+          wrapDeserialize(vortexExt, vortexApiLib, fullFeatureSetAvailablePostStartup, internalLoadOrderer),
+        serializeLoadOrder:
+          wrapSerialize(vortexExt, vortexApiLib, fullFeatureSetAvailablePostStartup, internalLoadOrderer),
       });
 
     } // if (IsFeatureEnabled(StaticFeaturesForStartup.REDmodLoadOrder))

--- a/src/load_order.types.ts
+++ b/src/load_order.types.ts
@@ -1,6 +1,12 @@
-import { pipe } from "fp-ts/lib/function";
-import { Ord as NumericOrd } from "fp-ts/lib/number";
-import { Ord as StringOrd } from "fp-ts/lib/string";
+import {
+  pipe,
+} from "fp-ts/lib/function";
+import {
+  Ord as NumericOrd,
+} from "fp-ts/lib/number";
+import {
+  Ord as StringOrd,
+} from "fp-ts/lib/string";
 import {
   contramap,
   Ord,
@@ -15,16 +21,39 @@ import {
   decodeWith,
   REDmodInfoForVortex,
 } from "./installers.types";
-import { jsonpp } from "./util.functions";
 import {
+  jsonpp,
+} from "./util.functions";
+import {
+  VortexApi,
+  VortexLoadOrder,
   VortexLoadOrderEntry,
   VortexModWithEnabledStatus,
-  VortexWrappedDeserializeFunc,
-  VortexWrappedSerializeFunc,
-  VortexWrappedValidateFunc,
+  VortexValidationResult,
 } from "./vortex-wrapper";
+import {
+  FeatureSet,
+} from "./features";
 
 export const LOAD_ORDER_TYPE_VERSION = `1.0.0`;
+
+export type VortexWrappedValidateFunc = (
+  vortexApi: VortexApi,
+  features: FeatureSet,
+  prev: VortexLoadOrder,
+  current: VortexLoadOrder
+) => Promise<VortexValidationResult>;
+
+export type VortexWrappedDeserializeFunc = (
+  vortexApi: VortexApi,
+  features: FeatureSet,
+) => Promise<VortexLoadOrder>;
+
+export type VortexWrappedSerializeFunc = (
+  vortexApi: VortexApi,
+  features: FeatureSet,
+  loadOrder: VortexLoadOrder,
+) => Promise<void>;
 
 export interface LoadOrderer {
   validate: VortexWrappedValidateFunc;

--- a/src/redmodding.metadata.ts
+++ b/src/redmodding.metadata.ts
@@ -12,3 +12,4 @@ export const V2077_LOAD_ORDER_DIR = path.join(`${V2077_DIR}\\Load Order`);
 
 export const REDlauncherExeRelativePath = path.join(`REDprelauncher.exe`);
 export const REDdeployExeRelativePath = path.join(`tools\\redmod\\bin\\redMod.exe`);
+

--- a/src/vortex-wrapper.ts
+++ b/src/vortex-wrapper.ts
@@ -73,23 +73,11 @@ export type VortexActionConditionFunc = (instanceIds?: string[]) => string | boo
 
 export type VortexValidateFunc =
    (prev: VortexLoadOrder, current: VortexLoadOrder) => Promise<VortexValidationResult>;
-export type VortexWrappedValidateFunc = (
-  vortexApi: VortexApi,
-  prev: VortexLoadOrder,
-  current: VortexLoadOrder
-) => Promise<VortexValidationResult>;
 
 export type VortexDeserializeFunc = () => Promise<VortexLoadOrder>;
-export type VortexWrappedDeserializeFunc = (
-  vortexApi: VortexApi,
-) => Promise<VortexLoadOrder>;
 
 export type VortexSerializeFunc =
   (loadOrder: VortexLoadOrder) => Promise<void>;
-export type VortexWrappedSerializeFunc = (
-  vortexApi: VortexApi,
-  loadOrder: VortexLoadOrder,
-) => Promise<void>;
 
 export type VortexLogLevel = "debug" | "info" | "warn" | "error";
 export type VortexLogFunc = (


### PR DESCRIPTION
Shell is limited to 8192 chars, we're hitting that. This has tradeoffs, see #313