### PR TITLE
✨ Don't tag autoconverted mod names (flagged)

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run post-commit
+#npm run post-commit
+echo "Post-commit hook is disabled, pack and test your own stuff"

--- a/src/features.ts
+++ b/src/features.ts
@@ -46,6 +46,7 @@ export const IfFeatureEnabled = <T>(featureState: FeatureState, then: Dynamic<T>
 export const enum StaticFeature {
   REDmodding = `v2077_feature_redmodding`,
   REDmodLoadOrder = `v2077_feature_redmod_load_order`,
+  REDmodAutoconversionTag = `v2077_feature_redmod_autoconversion_tag`,
   // TODO: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/313
   //
   //       Maybe we can do something better here? This will only increase
@@ -87,6 +88,7 @@ export const BaselineFeatureSetForTests: FeatureSet = {
   fromVersion: `0.9.3`,
   REDmodding: FeatureState.Disabled,
   REDmodLoadOrder: FeatureState.Disabled,
+  REDmodAutoconversionTag: FeatureState.Enabled,
   ExePreferDirectSpawnWithoutShell: FeatureState.Disabled,
   REDmodAutoconvertArchives: () => FeatureState.Disabled,
 };
@@ -95,6 +97,7 @@ export const StaticFeaturesForStartup: VersionedStaticFeatureSet = {
   fromVersion: `0.9.3`,
   REDmodding: FeatureState.Enabled,
   REDmodLoadOrder: FeatureState.Enabled,
+  REDmodAutoconversionTag: FeatureState.Disabled,
   ExePreferDirectSpawnWithoutShell: FeatureState.Enabled,
 };
 

--- a/src/features.ts
+++ b/src/features.ts
@@ -46,6 +46,19 @@ export const IfFeatureEnabled = <T>(featureState: FeatureState, then: Dynamic<T>
 export const enum StaticFeature {
   REDmodding = `v2077_feature_redmodding`,
   REDmodLoadOrder = `v2077_feature_redmod_load_order`,
+  // TODO: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/313
+  //
+  //       Maybe we can do something better here? This will only increase
+  //       the limit from 8192 to 32k anyway, but that does give us headroom.
+  //       Just kind of a worse UX until and if we come up with a spinner-like.
+  //
+  //       And error handling might be trickier.
+  //
+  // TODO: https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/316
+  //
+  //       Turn this into a DynamicFeature once we have a solid way to
+  //       directly derive the settings from it #278
+  ExePreferDirectSpawnWithoutShell = `v2077_feature_exe_prefer_direct_spawn_without_shell`,
 }
 
 // Need to be underscored since it isn't always just a string... thanks react...
@@ -71,16 +84,18 @@ export type FeatureSet = VersionedStaticFeatureSet & DynamicFeatureSet;
 // ...Through these records
 
 export const BaselineFeatureSetForTests: FeatureSet = {
-  fromVersion: `0.9.0`,
+  fromVersion: `0.9.3`,
   REDmodding: FeatureState.Disabled,
   REDmodLoadOrder: FeatureState.Disabled,
+  ExePreferDirectSpawnWithoutShell: FeatureState.Disabled,
   REDmodAutoconvertArchives: () => FeatureState.Disabled,
 };
 
 export const StaticFeaturesForStartup: VersionedStaticFeatureSet = {
-  fromVersion: `0.9.0`,
+  fromVersion: `0.9.3`,
   REDmodding: FeatureState.Enabled,
   REDmodLoadOrder: FeatureState.Enabled,
+  ExePreferDirectSpawnWithoutShell: FeatureState.Enabled,
 };
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,9 +276,12 @@ const main = (vortexExt: VortexExtensionContext): boolean => {
         // toggleableEntries: true,
         //
         usageInstructions: loadOrderUsageInstructionsForVortexGui,
-        validate: wrapValidate(vortexExt, vortexApiLib, internalLoadOrderer),
-        deserializeLoadOrder: wrapDeserialize(vortexExt, vortexApiLib, internalLoadOrderer),
-        serializeLoadOrder: wrapSerialize(vortexExt, vortexApiLib, internalLoadOrderer),
+        validate:
+          wrapValidate(vortexExt, vortexApiLib, fullFeatureSetAvailablePostStartup, internalLoadOrderer),
+        deserializeLoadOrder:
+          wrapDeserialize(vortexExt, vortexApiLib, fullFeatureSetAvailablePostStartup, internalLoadOrderer),
+        serializeLoadOrder:
+          wrapSerialize(vortexExt, vortexApiLib, fullFeatureSetAvailablePostStartup, internalLoadOrderer),
       });
 
     } // if (IsFeatureEnabled(StaticFeaturesForStartup.REDmodLoadOrder))

--- a/src/installer.redmod.ts
+++ b/src/installer.redmod.ts
@@ -767,7 +767,7 @@ export const transformToREDmodArchiveInstructions = async (
   }
 
   const redmodInfoWithAutoconvertTag =
-    modInfoTaggedAsAutoconverted(modInfo);
+    modInfoTaggedAsAutoconverted(features, modInfo);
 
   const redmodModuleName =
     redmodInfoWithAutoconvertTag.name;

--- a/src/installers.shared.ts
+++ b/src/installers.shared.ts
@@ -12,13 +12,17 @@ import {
   identity,
   pipe,
 } from "fp-ts/lib/function";
-import { Task } from "fp-ts/lib/Task";
+import {
+  Task,
+} from "fp-ts/lib/Task";
 import * as T from "fp-ts/Task";
 import {
   TaskEither,
   tryCatch,
 } from "fp-ts/lib/TaskEither";
-import { promptUserOnProtectedPaths } from "./ui.dialogs";
+import {
+  promptUserOnProtectedPaths,
+} from "./ui.dialogs";
 import {
   Path,
   File,
@@ -53,6 +57,10 @@ import {
   VortexApi,
   VortexInstruction,
 } from "./vortex-wrapper";
+import {
+  FeatureSet,
+  IsFeatureEnabled,
+} from "./features";
 
 
 //
@@ -141,32 +149,35 @@ export const makeSyntheticModInfo =
    });
 
 //
-export const modInfoTaggedAsAutoconverted = (modInfo: ModInfo): ModInfo => {
-  const modNameWithoutExtraTag =
+export const modInfoTaggedAsAutoconverted =
+  (features: FeatureSet, modInfo: ModInfo): ModInfo => {
+    const modNameWithoutExtraTag =
     modInfo.name.replace(V2077_GENERATED_MOD_NAME_TAG, ``);
 
-  const modNameTaggedAsAutoconverted =
-    `${modNameWithoutExtraTag} ${REDMOD_AUTOCONVERTED_NAME_TAG}`;
+    const modNameToUseForModInfo =
+      IsFeatureEnabled(features.REDmodAutoconversionTag)
+        ? `${modNameWithoutExtraTag} ${REDMOD_AUTOCONVERTED_NAME_TAG}`
+        : modNameWithoutExtraTag;
 
-  const existingBuildTagMustBeModified =
+    const existingBuildTagMustBeModified =
     modInfo.version.build && modInfo.version.build !== ``;
 
-  const tagSeparator =
+    const tagSeparator =
     existingBuildTagMustBeModified ? `-` : ``;
 
-  const taggedBuildVersion =
+    const taggedBuildVersion =
       `${modInfo.version.build || ``}${tagSeparator}${REDMOD_AUTOCONVERTED_VERSION_TAG}`;
 
-  return makeModInfo({
-    ...modInfo,
-    name: modNameTaggedAsAutoconverted,
-    version: {
-      ...modInfo.version,
-      build: taggedBuildVersion,
-    },
-    createTime: dateToSeconds(modInfo.createTime),
-  });
-};
+    return makeModInfo({
+      ...modInfo,
+      name: modNameToUseForModInfo,
+      version: {
+        ...modInfo.version,
+        build: taggedBuildVersion,
+      },
+      createTime: dateToSeconds(modInfo.createTime),
+    });
+  };
 
 //
 // Parsing

--- a/src/load_order.types.ts
+++ b/src/load_order.types.ts
@@ -1,6 +1,12 @@
-import { pipe } from "fp-ts/lib/function";
-import { Ord as NumericOrd } from "fp-ts/lib/number";
-import { Ord as StringOrd } from "fp-ts/lib/string";
+import {
+  pipe,
+} from "fp-ts/lib/function";
+import {
+  Ord as NumericOrd,
+} from "fp-ts/lib/number";
+import {
+  Ord as StringOrd,
+} from "fp-ts/lib/string";
 import {
   contramap,
   Ord,
@@ -15,16 +21,39 @@ import {
   decodeWith,
   REDmodInfoForVortex,
 } from "./installers.types";
-import { jsonpp } from "./util.functions";
 import {
+  jsonpp,
+} from "./util.functions";
+import {
+  VortexApi,
+  VortexLoadOrder,
   VortexLoadOrderEntry,
   VortexModWithEnabledStatus,
-  VortexWrappedDeserializeFunc,
-  VortexWrappedSerializeFunc,
-  VortexWrappedValidateFunc,
+  VortexValidationResult,
 } from "./vortex-wrapper";
+import {
+  FeatureSet,
+} from "./features";
 
 export const LOAD_ORDER_TYPE_VERSION = `1.0.0`;
+
+export type VortexWrappedValidateFunc = (
+  vortexApi: VortexApi,
+  features: FeatureSet,
+  prev: VortexLoadOrder,
+  current: VortexLoadOrder
+) => Promise<VortexValidationResult>;
+
+export type VortexWrappedDeserializeFunc = (
+  vortexApi: VortexApi,
+  features: FeatureSet,
+) => Promise<VortexLoadOrder>;
+
+export type VortexWrappedSerializeFunc = (
+  vortexApi: VortexApi,
+  features: FeatureSet,
+  loadOrder: VortexLoadOrder,
+) => Promise<void>;
 
 export interface LoadOrderer {
   validate: VortexWrappedValidateFunc;

--- a/src/redmodding.metadata.ts
+++ b/src/redmodding.metadata.ts
@@ -12,3 +12,4 @@ export const V2077_LOAD_ORDER_DIR = path.join(`${V2077_DIR}\\Load Order`);
 
 export const REDlauncherExeRelativePath = path.join(`REDprelauncher.exe`);
 export const REDdeployExeRelativePath = path.join(`tools\\redmod\\bin\\redMod.exe`);
+

--- a/src/vortex-wrapper.ts
+++ b/src/vortex-wrapper.ts
@@ -73,23 +73,11 @@ export type VortexActionConditionFunc = (instanceIds?: string[]) => string | boo
 
 export type VortexValidateFunc =
    (prev: VortexLoadOrder, current: VortexLoadOrder) => Promise<VortexValidationResult>;
-export type VortexWrappedValidateFunc = (
-  vortexApi: VortexApi,
-  prev: VortexLoadOrder,
-  current: VortexLoadOrder
-) => Promise<VortexValidationResult>;
 
 export type VortexDeserializeFunc = () => Promise<VortexLoadOrder>;
-export type VortexWrappedDeserializeFunc = (
-  vortexApi: VortexApi,
-) => Promise<VortexLoadOrder>;
 
 export type VortexSerializeFunc =
   (loadOrder: VortexLoadOrder) => Promise<void>;
-export type VortexWrappedSerializeFunc = (
-  vortexApi: VortexApi,
-  loadOrder: VortexLoadOrder,
-) => Promise<void>;
 
 export type VortexLogLevel = "debug" | "info" | "warn" | "error";
 export type VortexLogFunc = (

--- a/test/unit/mods.example.redmod.autoconversion.ts
+++ b/test/unit/mods.example.redmod.autoconversion.ts
@@ -62,11 +62,22 @@ const FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES: FeatureSet = {
   REDmodAutoconvertArchives: () => FeatureState.Enabled,
 };
 
+const FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES_WITHOUT_TAGGING: FeatureSet = {
+  ...BaselineFeatureSetForTests,
+  REDmodAutoconversionTag: FeatureState.Disabled,
+  REDmodAutoconvertArchives: () => FeatureState.Enabled,
+};
+
 const AUTOCONVERT_MOD_NAME = `${FAKE_MOD_INFO.name} ${REDMOD_AUTOCONVERTED_NAME_TAG}`;
+const AUTOCONVERT_MOD_NAME_UNTAGGED = `${FAKE_MOD_INFO.name}`;
 const AUTOCONVERT_MOD_VERSION = `${FAKE_MOD_INFO.version.v}+V2077RED`;
 
 const REDMOD_FAKE_INFO: REDmodInfo = {
   name: AUTOCONVERT_MOD_NAME,
+  version: AUTOCONVERT_MOD_VERSION,
+};
+const REDMOD_FAKE_INFO_UNTAGGED: REDmodInfo = {
+  name: AUTOCONVERT_MOD_NAME_UNTAGGED,
   version: AUTOCONVERT_MOD_VERSION,
 };
 const REDMOD_FAKE_INFO_FOR_VORTEX: REDmodInfoForVortex = {
@@ -75,6 +86,12 @@ const REDMOD_FAKE_INFO_FOR_VORTEX: REDmodInfoForVortex = {
   vortexModId: FAKE_MOD_INFO.id,
 };
 const REDMOD_FAKE_INFO_JSON = jsonpp(REDMOD_FAKE_INFO);
+const REDMOD_FAKE_INFO_FOR_VORTEX_UNTAGGED: REDmodInfoForVortex = {
+  ...REDMOD_FAKE_INFO_UNTAGGED,
+  relativePath: normalizeDir(path.join(REDMOD_BASEDIR, REDMOD_FAKE_INFO_UNTAGGED.name)),
+  vortexModId: FAKE_MOD_INFO.id,
+};
+const REDMOD_FAKE_INFO_UNTAGGED_JSON = jsonpp(REDMOD_FAKE_INFO_UNTAGGED);
 
 const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod>([
   [
@@ -98,6 +115,31 @@ const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod
         createdDirectory(REDMOD_SCRIPTS_MODDED_DIR),
         addedMetadataAttribute(REDMOD_MODTYPE_ATTRIBUTE),
         addedREDmodInfoArrayAttribute(REDMOD_FAKE_INFO_FOR_VORTEX),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+  [
+    `Canonical with single archive migrated to REDmod without name tagging`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES_WITHOUT_TAGGING,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_NAME_UNTAGGED}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_UNTAGGED_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_NAME_UNTAGGED}\\${REDMOD_INFO_FILENAME}`),
+        ),
+        createdDirectory(REDMOD_SCRIPTS_MODDED_DIR),
+        addedMetadataAttribute(REDMOD_MODTYPE_ATTRIBUTE),
+        addedREDmodInfoArrayAttribute(REDMOD_FAKE_INFO_FOR_VORTEX_UNTAGGED),
       ],
       infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
     },


### PR DESCRIPTION
This'll reduce the command line length that's bottlenecking `redMod.exe` calls. Version still has the tag.

Users will need to reinstall any mod they want to strip the tag from.