### PR TITLE
🔖 v0.9.3

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run post-commit
+#npm run post-commit
+echo "Post-commit hook is disabled, pack and test your own stuff"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Cyberpunk 2077 Vortex Support v0.9.3
+
+Quick and dirty, 'cause what else is there in Night City?
+
+## Fixer Gigs
+
+- 🐛 **cYbEr PuNk 2o77 Ex3** Since the 'case-insensitive' Windows filesystem doesn't _actually_ do a whole lot to guarantee any protection against any sort of problem, much like NCPD, there's a minor workaround to allow `cybercmd` to use case-sensitive comparison (until their fix is in.) To wit, we now spell `Cyberpunk2077` as `Cyberpunk2077`, not `cyberpunk2077`. Computers are great.
+
+- 🐛 **:spy:** No more autoconvert tags in mod names to reduce the name length, which is actually becoming a problem with ~200 REDmods installed. This defers the problem slightly, but we need to solve it better unless the next version of `redMod.exe` will allow file-based input.
+
+- 🐛 **DND: off** Show notifications for starting _and_ completing an on-demand REDdeployment.
+
+---
 # Cyberpunk 2077 Vortex Support v0.9.2
 
 A nice new gig and a bit of fixing for v0.9.0
@@ -16,6 +29,7 @@ A nice new gig and a bit of fixing for v0.9.0
 
 - ⚒️ **Run the game directly, `-modded`, no launcher.** If you don't need the launcher, you can launch the game directly and still get the modded goodness (it's in the toolbar at the top, or on your dashboard.) 
 
+---
 
 # Cyberpunk 2077 Vortex Support v0.9.1
 
@@ -23,6 +37,8 @@ Bugfix update to v0.9.0, see full changelog below.
 ## Fixer Gigs
 
 - 🐞 **Tools from other games won't crash if user has our extension but the game is not installed**. Until and if Vortex offers isolation from other games touching our stuff, we need to be extra careful not to touch any CP2077-specific stuff until we know that the user is actually invoking one of our tools.
+
+---
 
 # Cyberpunk 2077 Vortex Support v0.9.0 "Rogue"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cyberpunk2077",
-    "version": "0.9.3-gonk",
+    "version": "0.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cyberpunk2077",
-            "version": "0.9.3-gonk",
+            "version": "0.9.3",
             "hasInstallScript": true,
             "license": "GPL-3.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cyberpunk2077",
-    "version": "0.9.3-gonk",
+    "version": "0.9.3",
     "description": "Cyberpunk 2077 modding support for the Vortex mod manager, as user-friendly and helpful as possible.",
     "homepage": "https://www.nexusmods.com/site/mods/196",
     "repository": "https://github.com/E1337Kat/cyberpunk2077_ext_redux",

--- a/src/features.ts
+++ b/src/features.ts
@@ -46,6 +46,7 @@ export const IfFeatureEnabled = <T>(featureState: FeatureState, then: Dynamic<T>
 export const enum StaticFeature {
   REDmodding = `v2077_feature_redmodding`,
   REDmodLoadOrder = `v2077_feature_redmod_load_order`,
+  REDmodAutoconversionTag = `v2077_feature_redmod_autoconversion_tag`,
 }
 
 // Need to be underscored since it isn't always just a string... thanks react...
@@ -71,16 +72,18 @@ export type FeatureSet = VersionedStaticFeatureSet & DynamicFeatureSet;
 // ...Through these records
 
 export const BaselineFeatureSetForTests: FeatureSet = {
-  fromVersion: `0.9.0`,
+  fromVersion: `0.9.3`,
   REDmodding: FeatureState.Disabled,
   REDmodLoadOrder: FeatureState.Disabled,
+  REDmodAutoconversionTag: FeatureState.Enabled,
   REDmodAutoconvertArchives: () => FeatureState.Disabled,
 };
 
 export const StaticFeaturesForStartup: VersionedStaticFeatureSet = {
-  fromVersion: `0.9.0`,
+  fromVersion: `0.9.3`,
   REDmodding: FeatureState.Enabled,
   REDmodLoadOrder: FeatureState.Enabled,
+  REDmodAutoconversionTag: FeatureState.Disabled,
 };
 
 

--- a/src/index.metadata.ts
+++ b/src/index.metadata.ts
@@ -16,7 +16,7 @@ export const EXTENSION_NAME_INTERNAL = `V2077`;
 export const EXTENSION_URL_NEXUS = `https://www.nexusmods.com/site/mods/196`;
 export const EXTENSION_URL_GITHUB = `https://github.com/E1337Kat/cyberpunk2077_ext_redux`;
 
-export const GAME_EXE_RELATIVE_PATH = `bin/x64/cyberpunk2077.exe`;
+export const GAME_EXE_RELATIVE_PATH = `bin/x64/Cyberpunk2077.exe`;
 
 export const V2077_DIR = `V2077`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,8 +257,8 @@ const main = (vortexExt: VortexExtensionContext): boolean => {
 
   pipe(
     availableStartHooks,
-    mapWithIndex((i: number, { hookId, transformRunParams }) =>
-      forEffect(() => { vortexExt.registerStartHook(40 + i, hookId, transformRunParams); })),
+    mapWithIndex((i: number, { hookId, doActualWorkInTheHookAndReturnDummyParams }) =>
+      forEffect(() => { vortexExt.registerStartHook(40 + i, hookId, doActualWorkInTheHookAndReturnDummyParams); })),
     forEachEffect,
     mapLeft((err) => {
       vortexApiLib.log(`error`, `${EXTENSION_NAME_INTERNAL} init: Failed to register start hook`, err);

--- a/src/installer.redmod.ts
+++ b/src/installer.redmod.ts
@@ -767,7 +767,7 @@ export const transformToREDmodArchiveInstructions = async (
   }
 
   const redmodInfoWithAutoconvertTag =
-    modInfoTaggedAsAutoconverted(modInfo);
+    modInfoTaggedAsAutoconverted(features, modInfo);
 
   const redmodModuleName =
     redmodInfoWithAutoconvertTag.name;

--- a/src/installers.shared.ts
+++ b/src/installers.shared.ts
@@ -12,13 +12,17 @@ import {
   identity,
   pipe,
 } from "fp-ts/lib/function";
-import { Task } from "fp-ts/lib/Task";
+import {
+  Task,
+} from "fp-ts/lib/Task";
 import * as T from "fp-ts/Task";
 import {
   TaskEither,
   tryCatch,
 } from "fp-ts/lib/TaskEither";
-import { promptUserOnProtectedPaths } from "./ui.dialogs";
+import {
+  promptUserOnProtectedPaths,
+} from "./ui.dialogs";
 import {
   Path,
   File,
@@ -53,6 +57,10 @@ import {
   VortexApi,
   VortexInstruction,
 } from "./vortex-wrapper";
+import {
+  FeatureSet,
+  IsFeatureEnabled,
+} from "./features";
 
 
 //
@@ -141,32 +149,35 @@ export const makeSyntheticModInfo =
    });
 
 //
-export const modInfoTaggedAsAutoconverted = (modInfo: ModInfo): ModInfo => {
-  const modNameWithoutExtraTag =
+export const modInfoTaggedAsAutoconverted =
+  (features: FeatureSet, modInfo: ModInfo): ModInfo => {
+    const modNameWithoutExtraTag =
     modInfo.name.replace(V2077_GENERATED_MOD_NAME_TAG, ``);
 
-  const modNameTaggedAsAutoconverted =
-    `${modNameWithoutExtraTag} ${REDMOD_AUTOCONVERTED_NAME_TAG}`;
+    const modNameToUseForModInfo =
+      IsFeatureEnabled(features.REDmodAutoconversionTag)
+        ? `${modNameWithoutExtraTag} ${REDMOD_AUTOCONVERTED_NAME_TAG}`
+        : modNameWithoutExtraTag;
 
-  const existingBuildTagMustBeModified =
+    const existingBuildTagMustBeModified =
     modInfo.version.build && modInfo.version.build !== ``;
 
-  const tagSeparator =
+    const tagSeparator =
     existingBuildTagMustBeModified ? `-` : ``;
 
-  const taggedBuildVersion =
+    const taggedBuildVersion =
       `${modInfo.version.build || ``}${tagSeparator}${REDMOD_AUTOCONVERTED_VERSION_TAG}`;
 
-  return makeModInfo({
-    ...modInfo,
-    name: modNameTaggedAsAutoconverted,
-    version: {
-      ...modInfo.version,
-      build: taggedBuildVersion,
-    },
-    createTime: dateToSeconds(modInfo.createTime),
-  });
-};
+    return makeModInfo({
+      ...modInfo,
+      name: modNameToUseForModInfo,
+      version: {
+        ...modInfo.version,
+        build: taggedBuildVersion,
+      },
+      createTime: dateToSeconds(modInfo.createTime),
+    });
+  };
 
 //
 // Parsing

--- a/src/tools.types.ts
+++ b/src/tools.types.ts
@@ -12,7 +12,7 @@ export type ToolRunParamTransformStartHookFunc =
 
 export interface ToolStartHook {
   readonly hookId: string;
-  readonly transformRunParams: ToolRunParamTransformStartHookFunc;
+  readonly doActualWorkInTheHookAndReturnDummyParams: ToolRunParamTransformStartHookFunc;
 }
 
 export type MakeToolStartHookWithStateFunc =

--- a/test/unit/mods.example.redmod.autoconversion.ts
+++ b/test/unit/mods.example.redmod.autoconversion.ts
@@ -62,11 +62,22 @@ const FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES: FeatureSet = {
   REDmodAutoconvertArchives: () => FeatureState.Enabled,
 };
 
+const FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES_WITHOUT_TAGGING: FeatureSet = {
+  ...BaselineFeatureSetForTests,
+  REDmodAutoconversionTag: FeatureState.Disabled,
+  REDmodAutoconvertArchives: () => FeatureState.Enabled,
+};
+
 const AUTOCONVERT_MOD_NAME = `${FAKE_MOD_INFO.name} ${REDMOD_AUTOCONVERTED_NAME_TAG}`;
+const AUTOCONVERT_MOD_NAME_UNTAGGED = `${FAKE_MOD_INFO.name}`;
 const AUTOCONVERT_MOD_VERSION = `${FAKE_MOD_INFO.version.v}+V2077RED`;
 
 const REDMOD_FAKE_INFO: REDmodInfo = {
   name: AUTOCONVERT_MOD_NAME,
+  version: AUTOCONVERT_MOD_VERSION,
+};
+const REDMOD_FAKE_INFO_UNTAGGED: REDmodInfo = {
+  name: AUTOCONVERT_MOD_NAME_UNTAGGED,
   version: AUTOCONVERT_MOD_VERSION,
 };
 const REDMOD_FAKE_INFO_FOR_VORTEX: REDmodInfoForVortex = {
@@ -75,6 +86,12 @@ const REDMOD_FAKE_INFO_FOR_VORTEX: REDmodInfoForVortex = {
   vortexModId: FAKE_MOD_INFO.id,
 };
 const REDMOD_FAKE_INFO_JSON = jsonpp(REDMOD_FAKE_INFO);
+const REDMOD_FAKE_INFO_FOR_VORTEX_UNTAGGED: REDmodInfoForVortex = {
+  ...REDMOD_FAKE_INFO_UNTAGGED,
+  relativePath: normalizeDir(path.join(REDMOD_BASEDIR, REDMOD_FAKE_INFO_UNTAGGED.name)),
+  vortexModId: FAKE_MOD_INFO.id,
+};
+const REDMOD_FAKE_INFO_UNTAGGED_JSON = jsonpp(REDMOD_FAKE_INFO_UNTAGGED);
 
 const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod>([
   [
@@ -98,6 +115,31 @@ const ArchiveModToREDmodMigrationSucceeds = new Map<string, ExampleSucceedingMod
         createdDirectory(REDMOD_SCRIPTS_MODDED_DIR),
         addedMetadataAttribute(REDMOD_MODTYPE_ATTRIBUTE),
         addedREDmodInfoArrayAttribute(REDMOD_FAKE_INFO_FOR_VORTEX),
+      ],
+      infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
+    },
+  ],
+  [
+    `Canonical with single archive migrated to REDmod without name tagging`,
+    {
+      features: FLAG_ENABLED_REDMOD_AUTOCONVERT_ARCHIVES_WITHOUT_TAGGING,
+      expectedInstallerType: InstallerType.Archive,
+      inFiles: [
+        ...ARCHIVE_PREFIXES,
+        path.join(`${ARCHIVE_PREFIX}/first.archive`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`${ARCHIVE_PREFIX}/first.archive`),
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_NAME_UNTAGGED}\\${REDMOD_ARCHIVES_DIRNAME}\\first.archive`),
+        ),
+        generatedFile(
+          REDMOD_FAKE_INFO_UNTAGGED_JSON,
+          path.join(`${REDMOD_BASEDIR}\\${AUTOCONVERT_MOD_NAME_UNTAGGED}\\${REDMOD_INFO_FILENAME}`),
+        ),
+        createdDirectory(REDMOD_SCRIPTS_MODDED_DIR),
+        addedMetadataAttribute(REDMOD_MODTYPE_ATTRIBUTE),
+        addedREDmodInfoArrayAttribute(REDMOD_FAKE_INFO_FOR_VORTEX_UNTAGGED),
       ],
       infoNotificationId: InfoNotification.REDmodArchiveAutoconverted,
     },


### PR DESCRIPTION
- 🐛 **cYbEr PuNk 2o77 Ex3** Since the 'case-insensitive' Windows filesystem doesn't _actually_ do a whole lot to guarantee any protection against any sort of problem, much like NCPD, there's a minor workaround to allow `cybercmd` to use case-sensitive comparison (until their fix is in.) To wit, we now spell `Cyberpunk2077` as `Cyberpunk2077`, not `cyberpunk2077`. Computers are great.

- 🐛 **:spy:** No more autoconvert tags in mod names to reduce the name length, which is actually becoming a problem with ~200 REDmods installed. This defers the problem slightly, but we need to solve it better unless the next version of `redMod.exe` will allow file-based input.

- 🐛 **DND: off** Show notifications for starting _and_ completing an on-demand REDdeployment.

---


    We can't get the exit status from the Tool, so in order to actually   
    communicate to the user, we do the actual work in the hook and        
    just run a dummy exe for the tool (because it has to have an exe      
    to run for some reason.)

    This should be generally useful for running anything we want as       
    a Tool but without having to have a separate executable or script     
    for each one.
