### PR TITLE
🐛 Allow ignoring the settings state in specific cases

### DIFF
--- a/src/load_order.ts
+++ b/src/load_order.ts
@@ -144,9 +144,9 @@ const enabledMarker = (mod: VortexModWithEnabledStatus): string =>
 // Helpers
 //
 
-const getDiscoveryPath = (
+export const getDiscoveryResult = (
   api: VortexApi,
-): string => {
+): VortexDiscoveryResult => {
   //
   const state = api.store.getState();
   const discovery: VortexDiscoveryResult = vortexUtil.getSafe(
@@ -154,6 +154,15 @@ const getDiscoveryPath = (
     [`settings`, `gameMode`, `discovered`, GAME_ID],
     {},
   );
+
+  return discovery;
+};
+
+const getDiscoveryPath = (
+  api: VortexApi,
+): string => {
+  //
+  const discovery: VortexDiscoveryResult = getDiscoveryResult(api);
 
   return discovery?.path;
 };


### PR DESCRIPTION
Ignore the state of the autoconvert settings when about to perform the action depending on if the REDmod DLC exists or not. This isn't really a great fix, but it works and if say the DLC is installed while a bunch of archives are being installed then only the ones after the DLC is installed will be autoconverted no big deal. I think this will work well enough till we could find a better solution.