### PR TITLE
🐛🛡️  Protected Load Order File Handling

### DIFF
--- a/src/installers.shared.ts
+++ b/src/installers.shared.ts
@@ -14,8 +14,8 @@ import {
 } from "fp-ts/lib/function";
 import {
   Task,
+  map as mapT,
 } from "fp-ts/lib/Task";
-import * as T from "fp-ts/Task";
 import {
   TaskEither,
   tryCatch,
@@ -68,8 +68,12 @@ import {
 //
 
 export const fileFromDisk = ({ relativePath, pathOnDisk }: Path): Task<File> =>
-  T.map((content: string) => ({ relativePath, pathOnDisk, content }))(() =>
-    fs.readFile(pathOnDisk, { encoding: `utf-8` }));
+  pipe(
+    () =>
+      fs.stat(path.dirname(pathOnDisk)).then(() =>
+        fs.readFile(pathOnDisk, { encoding: `utf-8` })),
+    mapT((content: string) => ({ relativePath, pathOnDisk, content })),
+  );
 
 export const fileFromDiskTE = ({ relativePath, pathOnDisk }: Path): TaskEither<Error, File> =>
   tryCatch(

--- a/src/load_order.ts
+++ b/src/load_order.ts
@@ -644,7 +644,8 @@ const deployAndSerializeNewLoadOrder: VortexWrappedSerializeFunc = (
 
   const v2077LoadOrder = makeV2077LoadOrderFrom(vortexLoadOrder, ownerVortexProfileId, loID);
 
-  vortexApi.log(`info`, `${me}: New load order ${loID} ready to be deployed and serialized!`, S(v2077LoadOrder));
+  vortexApi.log(`info`, `${me}: New load order ${loID} ready to be deployed and serialized!`);
+  vortexApi.log(`debug`, `${me}: Load order ${loID}:`, S(v2077LoadOrder));
 
   // We want to wait until there's been a deployment - either the automatic one
   // from an enable or something like that, or a manually triggered one.

--- a/src/load_order.ts
+++ b/src/load_order.ts
@@ -109,6 +109,9 @@ import {
   InfoNotification,
   showInfoNotification,
 } from "./ui.notifications";
+import {
+  showInvalidLoadOrderFileErrorDialog,
+} from "./ui.dialogs";
 
 // Ensure we're using win32 conventions
 const path = win32;
@@ -365,9 +368,12 @@ const compileDetesToGenerateLoadOrderUi: VortexWrappedDeserializeFunc = async (
   )();
 
   // The rest of this function could and should be refactored into a pipeline
+  // to get rid of this early return
 
   if (isLeft(deserializedLoadOrder)) {
     vortexApi.log(`error`, `${me}: Error deserializing load order: ${deserializedLoadOrder.left.message}`);
+    showInvalidLoadOrderFileErrorDialog(vortexApi, loadOrderPathFor(activeProfile, gameDirPath));
+
     return Promise.reject(deserializedLoadOrder.left);
   }
 

--- a/src/ui.dialogs.ts
+++ b/src/ui.dialogs.ts
@@ -493,3 +493,31 @@ export const showManualStepRequiredForToolInfo = (
     [{ label: `Understood!` }],
   );
 };
+
+export const showInvalidLoadOrderFileErrorDialog = (
+  api: VortexApi,
+  loadOrderFilePath: string,
+): void =>
+  api.showDialog(
+    `error`,
+    `Error Loading Stored Load Order`,
+    {
+      md: heredoc(`
+        I was unable to load the stored Load Order in ${loadOrderFilePath}!
+
+        This means you need to resolve the error before you can continue.
+
+        If you edited the file manually, make sure it's valid JSON and in the correct format.
+
+        If you haven't touched it yourself, it's possible the file has become corrupted,
+        or this error may be transient and go away if you try again. If it doesn't:
+
+        Easiest solution:
+
+        1. Make sure the Load Order is correct in Vortex
+        2. Delete ${loadOrderFilePath} (or rename/move it if you want to examine/fix it)
+        3. Either move something in the Load Order (you can then move it back), or just restart Vortex
+      `),
+    },
+    [{ label: `Understood!` }],
+  );

--- a/src/ui.notifications.ts
+++ b/src/ui.notifications.ts
@@ -21,6 +21,7 @@ export const enum NotificationStatus {
 export const enum InfoNotification {
   InstallerExtraFilesMoved = `V2077-notify-info-installer-extrafilesmoved`,
   CyberCatRestartRequired = `V2077-notify-info-restart-required`,
+  LoadOrderWriteFailed = `V2077-notify-error-loadorder-write-failed`,
   REDmodArchiveAutoconverted = `V2077-notify-success-redmod-archive-autoconverted`,
   REDmodArchiveNOTautoconverted = `V2077-notify-info-redmod-archive-NOT-autoconverted`,
   REDmodDeploymentQueued = `V2077-notify-info-redmod-deployment-queued`,
@@ -51,6 +52,15 @@ const InfoNotificationsUnsafeMap = new Map<InfoNotification, Notification>([
       type: `info`,
       title: `Vortex Restart Required`,
       message: `To complete installing CyberCAT, wait for the deploy to finish and then restart Vortex!`,
+    },
+  ],
+  [
+    InfoNotification.LoadOrderWriteFailed,
+    {
+      id: InfoNotification.LoadOrderWriteFailed,
+      type: `error`,
+      title: `Writing Load Order to Disk Failed!`,
+      message: `Couldn't write the new load order to disk. Check the log for details!`,
     },
   ],
   [
@@ -104,7 +114,7 @@ const InfoNotificationsUnsafeMap = new Map<InfoNotification, Notification>([
       id: InfoNotification.REDmodDeploymentFailed,
       type: `error`,
       title: `REDmod Deployment Failed!`,
-      message: `Oh no! Something went wrong with the REDmod deployment. Check Diagnostic Files for details!`,
+      message: `Oh no! Something went wrong with the REDmod deployment. Check the log for details!`,
     },
   ],
   [

--- a/test/shimmed/vortex-api-test-shimmed.ts
+++ b/test/shimmed/vortex-api-test-shimmed.ts
@@ -1,4 +1,6 @@
-import { VortexProfile } from "../../src/vortex-wrapper";
+import {
+  VortexProfile,
+} from "../../src/vortex-wrapper";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const fail = (...args: any[]) => {
@@ -17,6 +19,7 @@ export const fs = {
   ensureDirWritableAsync: jest.fn(),
   statAsync: jest.fn(),
   writeFileAsync: jest.fn(),
+  renameAsync: jest.fn(),
 };
 
 export const selectors = {


### PR DESCRIPTION
## Exec Smry: Fixy the bug and add the protecc

🛡️ Protect load order from being overwritten in transient/persistent error cases
🐛 Separate handling for no LO file (ok) and unable to decode existing file (nok)
🐛 User has to manually fix an invalid LO file

🛡️ Writing LO to disk uses a tempfile to avoid possible race conditions from multiple deployments

📰 (Slightly) better errors from splitting `stat` for dir and actual file ops, plus dialog/notif

Closes #346 and #351 