### PR TITLE
🐛 Support REDmod With Only `info.json` Containing `mod_skip` Sounds

### DIFF
--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -648,32 +648,37 @@ export const enum REDmodLayout {
           One or more mods in the canonical REDmod layout of
 
           | - .\\mods\\[modname]\\info.json { name: modname, ... }
-          | - .\\mods\\[modname]\\archives\\[*.archive, *.xl]
-          | - .\\mods\\[modname]\\customSounds\\*.wav
-          | - .\\mods\\[modname]\\scripts\\[valid script subdir]\\[*.script, *.ws]
-          | - .\\mods\\[modname]\\tweaks\\base\\gameplay\\static_data\\*.tweak
-
-          There may additionally be a placeholder file to ensure the script dir exists
-
-          | - .\\r6\\cache\\modded\\[any .txt or no-extension files]
+          |   - .\\mods\\[modname]\\archives\\[*.archive, *.xl]
+          |   - .\\mods\\[modname]\\customSounds\\*.wav
+          |   - .\\mods\\[modname]\\scripts\\[valid script subdir]\\[*.script, *.ws]
+          |   - .\\mods\\[modname]\\tweaks\\base\\gameplay\\static_data\\*.tweak
           `,
+
+  InfoOnly = `
+          Or the special case for info-only mods (currently ONLY for \`mod_skip\` audio mods,
+          only supported in canonical layout:
+
+          | - .\\mods\\[modname]\\info.json { name: modname, customSounds: [ { name: 'hi', type: 'mod_skip' } ... } ]
+          `,
+
   Named = `
-          Without the top-level mods\\, one or more mods in the form of
+          Without the top-level mods\\ directory, one or more mods in the form of
 
           | - .\\[modname]\\info.json { name: modname, ... }
-          | - .\\[modname]\\archives\\[*.archive, *.xl]
-          | - .\\[modname]\\customSounds\\*.wav
-          | - .\\[modname]\\scripts\\[valid script subdir]\\[*.script, *.ws]
-          | - .\\[modname]\\tweaks\\base\\gameplay\\static_data\\*.tweak
+          |   - .\\[modname]\\archives\\[*.archive, *.xl]
+          |   - .\\[modname]\\customSounds\\*.wav
+          |   - .\\[modname]\\scripts\\[valid script subdir]\\[*.script, *.ws]
+          |   - .\\[modname]\\tweaks\\base\\gameplay\\static_data\\*.tweak
           `,
+
   Toplevel = `
           Single mod in the form of
 
           | - .\\info.json { name: modname, ... }
-          | - .\\archives\\[*.archive, *.xl]
-          | - .\\customSounds\\*.wav
-          | - .\\scripts\\[valid script subdir]\\[*.script, *.ws]
-          | - .\\tweaks\\base\\gameplay\\static_data\\*.tweak
+          |   - .\\archives\\[*.archive, *.xl]
+          |   - .\\customSounds\\*.wav
+          |   - .\\scripts\\[valid script subdir]\\[*.script, *.ws]
+          |   - .\\tweaks\\base\\gameplay\\static_data\\*.tweak
           `,
 }
 
@@ -965,6 +970,7 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
     InstallerType.REDmod,
     `
     - \`${REDmodLayout.Canon}\` (Canonical)
+    - \`${REDmodLayout.InfoOnly}\` (Special case)
     - \`${REDmodLayout.Named}\` (Can be fixed to canonical)
     - \`${REDmodLayout.Toplevel}\` (Can be fixed to canonical)
 

--- a/test/unit/mods.example.redmod.ts
+++ b/test/unit/mods.example.redmod.ts
@@ -806,6 +806,33 @@ const REDmodSpecialValidationSucceeds = new Map<string, ExampleSucceedingMod>([
       ],
     },
   ],
+  [
+    `Canonical REDmod without any files except info.json if info customSounds only has skip files`,
+    {
+      expectedInstallerType: InstallerType.REDmod,
+      fsMocked: mockedFsLayout(
+        {
+          [REDMOD_BASEDIR]: {
+            myRedMod: {
+              [REDMOD_INFO_FILENAME]: myREDmodInfoWithSkipSoundJson,
+            },
+          },
+        },
+      ),
+      inFiles: [
+        path.join(`mods/myRedMod/info.json`),
+      ],
+      outInstructions: [
+        movedFromTo(
+          path.join(`mods/myRedMod/info.json`),
+          path.join(`${REDMOD_BASEDIR}/myRedMod/info.json`),
+        ),
+        createdDirectory(REDMOD_SCRIPTS_MODDED_DIR),
+        addedMetadataAttribute(REDMOD_MODTYPE_ATTRIBUTE),
+        addedREDmodInfoArrayAttribute(myREDmodInfoWithSkipSoundForVortex),
+      ],
+    },
+  ],
 ]);
 
 

--- a/test/unit/mods.example.redmod.ts
+++ b/test/unit/mods.example.redmod.ts
@@ -681,7 +681,7 @@ const REDmodSpecialValidationSucceeds = new Map<string, ExampleSucceedingMod>([
       expectedInstallerType: InstallerType.REDmod,
       fsMocked: mockedFsLayout(
         {
-          [REDMOD_INFO_FILENAME]: myREDmodInfoWithSkipSoundJson,
+          [REDMOD_INFO_FILENAME]: myREDmodInfoJson,
         },
       ),
       inFiles: [
@@ -710,7 +710,7 @@ const REDmodSpecialValidationSucceeds = new Map<string, ExampleSucceedingMod>([
       expectedInstallerType: InstallerType.REDmod,
       fsMocked: mockedFsLayout(
         {
-          [REDMOD_INFO_FILENAME]: myREDmodInfoWithSkipSoundJson,
+          [REDMOD_INFO_FILENAME]: myREDmodInfoJson,
         },
       ),
       inFiles: [
@@ -746,7 +746,7 @@ const REDmodSpecialValidationSucceeds = new Map<string, ExampleSucceedingMod>([
       expectedInstallerType: InstallerType.REDmod,
       fsMocked: mockedFsLayout(
         {
-          [REDMOD_INFO_FILENAME]: myREDmodInfoWithSkipSoundJson,
+          [REDMOD_INFO_FILENAME]: myREDmodInfoJson,
         },
       ),
       inFiles: [
@@ -1027,6 +1027,28 @@ const REDmodDirectFailures = new Map<string, ExampleFailingMod>([
         path.join(`${REDMOD_BASEDIR}/info.json`),
         path.join(`${REDMOD_BASEDIR}/archives/`),
         path.join(`${REDMOD_BASEDIR}/archives/cool_stuff.archive`),
+      ],
+      failure: `Didn't Find Expected REDmod Installation!`,
+      errorDialogTitle: `Didn't Find Expected REDmod Installation!`,
+    },
+  ],
+  [
+    `REDmod with only an info.json that is not a known special case`,
+    {
+      expectedInstallerType: InstallerType.REDmod,
+      fsMocked: mockedFsLayout(
+        {
+          [REDMOD_BASEDIR]: {
+            myRedMod: {
+              [REDMOD_INFO_FILENAME]: myREDmodInfoJson,
+            },
+          },
+        },
+      ),
+      inFiles: [
+        path.join(`${REDMOD_BASEDIR}/`),
+        path.join(`${REDMOD_BASEDIR}/myRedMod/`),
+        path.join(`${REDMOD_BASEDIR}/myRedMod/info.json`),
       ],
       failure: `Didn't Find Expected REDmod Installation!`,
       errorDialogTitle: `Didn't Find Expected REDmod Installation!`,

--- a/test/unit/mods.example.redmod.ts
+++ b/test/unit/mods.example.redmod.ts
@@ -8,6 +8,7 @@ import {
 import path from "path";
 import {
   REDMOD_BASEDIR,
+  REDMOD_CUSTOMSOUNDS_DIRNAME,
   REDMOD_INFO_FILENAME,
   REDMOD_MODTYPE_ATTRIBUTE,
   REDMOD_SCRIPTS_MODDED_DIR,
@@ -827,6 +828,7 @@ const REDmodSpecialValidationSucceeds = new Map<string, ExampleSucceedingMod>([
           path.join(`mods/myRedMod/info.json`),
           path.join(`${REDMOD_BASEDIR}/myRedMod/info.json`),
         ),
+        createdDirectory(path.join(`${REDMOD_BASEDIR}/myRedMod`, REDMOD_CUSTOMSOUNDS_DIRNAME)),
         createdDirectory(REDMOD_SCRIPTS_MODDED_DIR),
         addedMetadataAttribute(REDMOD_MODTYPE_ATTRIBUTE),
         addedREDmodInfoArrayAttribute(myREDmodInfoWithSkipSoundForVortex),


### PR DESCRIPTION
Supports this structure with or without the empty `customSounds` dir as a special case when the `info.json` contains only `mod_skip` audio instructions.
```
|   af.zip
|
\---mods
    \---AF
        |   info.json
        |
        \---customSounds
```

This was way too difficult a fix, need some more metadata in the REDmod pipeline. 

Filetree not supporting empty dirs doesn't help (and it's not entirely straightforward to make it happen even without switching the rest of the code over.)

closes #356 