### PR TITLE
🔖 v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Cyberpunk 2077 Vortex Support v0.9.8
+
+## Main Jobs
+
+- ✨ **Input Loader v0.1.1 Support** (and you can still install v0.1.0, too, but shouldn't.)
+
+## Cyberdeck Upgrades aka Internal Stuff(tm)
+
+- 🛡️ **More Robust Load Order Protection** There were some cases in which a race condition or unexpectedly deleted `V2077` directory could cause the Load Order to be reset. Put a Cerberus on it, see 'em weefles try it now.
+
+---
+
+
 # Cyberpunk 2077 Vortex Support v0.9.7
 
 ## Fixer Gigs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cyberpunk2077",
-    "version": "0.9.8-gonk",
+    "version": "0.9.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cyberpunk2077",
-            "version": "0.9.8-gonk",
+            "version": "0.9.8",
             "hasInstallScript": true,
             "license": "GPL-3.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cyberpunk2077",
-    "version": "0.9.8-gonk",
+    "version": "0.9.8",
     "description": "Cyberpunk 2077 modding support for the Vortex mod manager, as user-friendly and helpful as possible.",
     "homepage": "https://www.nexusmods.com/site/mods/196",
     "repository": "https://github.com/E1337Kat/cyberpunk2077_ext_redux",


### PR DESCRIPTION
# Cyberpunk 2077 Vortex Support v0.9.8

## Main Jobs

- ✨ **Input Loader v0.1.1 Support** (and you can still install v0.1.0, too, but shouldn't.)

## Cyberdeck Upgrades aka Internal Stuff(tm)

- 🛡️ **More Robust Load Order Protection** There were some cases in which a race condition or unexpectedly deleted `V2077` directory could cause the Load Order to be reset. Put a Cerberus on it, see 'em weefles try it now.