### PR TITLE
Add Mod Settings support and allow red4ext to install .reds files

### DIFF
--- a/src/installer.core.modsettings.ts
+++ b/src/installer.core.modsettings.ts
@@ -1,0 +1,120 @@
+
+import {
+  VortexApi,
+  VortexTestResult,
+  VortexInstruction,
+} from "./vortex-wrapper";
+import {
+  FileTree,
+  fileCount,
+  pathInTree,
+  sourcePaths,
+} from "./filetree";
+import {
+  InstallerType,
+  ModInfo,
+  V2077InstallFunc,
+  V2077TestFunc,
+} from "./installers.types";
+import {
+  showWarningForUnrecoverableStructureError,
+} from "./ui.dialogs";
+import {
+  MOD_SETTINGS_CORE_FILES,
+} from "./installers.layouts";
+import {
+  FeatureSet,
+} from "./features";
+
+const me = InstallerType.CoreModSettings;
+
+const CoreModSettingsInstructions: VortexInstruction[] = [
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\license.md`,
+    destination: `red4ext\\plugins\\mod_settings\\license.md`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\readme.md`,
+    destination: `red4ext\\plugins\\mod_settings\\readme.md`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\ModSettings.archive`,
+    destination: `red4ext\\plugins\\mod_settings\\ModSettings.archive`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\ModSettings.archive.xl`,
+    destination: `red4ext\\plugins\\mod_settings\\ModSettings.archive.xl`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\mod_settings.dll`,
+    destination: `red4ext\\plugins\\mod_settings\\mod_settings.dll`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\module.reds`,
+    destination: `red4ext\\plugins\\mod_settings\\module.reds`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\mod_settings\\packed.reds`,
+    destination: `red4ext\\plugins\\mod_settings\\packed.reds`,
+  },
+];
+
+
+const findCoreModSettingsFiles = (fileTree: FileTree): string[] => [
+  ...MOD_SETTINGS_CORE_FILES.filter((requiredFile) => pathInTree(requiredFile, fileTree)),
+];
+
+
+const detectCoreModSettings = (fileTree: FileTree): boolean =>
+  // We just need to know this looks like it should be a core mod settings installation, for errors
+  findCoreModSettingsFiles(fileTree).length > 0;
+
+
+// test
+
+export const testForCoreModSettings: V2077TestFunc = (
+  _api: VortexApi,
+  fileTree: FileTree,
+): Promise<VortexTestResult> =>
+  Promise.resolve({ supported: detectCoreModSettings(fileTree), requiredFiles: [] });
+
+
+// install
+
+
+export const installCoreModSettings: V2077InstallFunc = async (
+  api: VortexApi,
+  fileTree: FileTree,
+  _modInfo: ModInfo,
+  _features: FeatureSet,
+) => {
+  const currentInstallationFiles = findCoreModSettingsFiles(fileTree);
+
+  if (currentInstallationFiles.length === fileCount(fileTree)
+    && currentInstallationFiles.length === MOD_SETTINGS_CORE_FILES.length) {
+    return Promise.resolve({ instructions: CoreModSettingsInstructions });
+  }
+
+  const errorMessage = `Didn't Find Expected Input Loader Installation!`;
+  api.log(
+    `error`,
+    `${me}: ${errorMessage}`,
+    sourcePaths(fileTree),
+  );
+
+  showWarningForUnrecoverableStructureError(
+    api,
+    me,
+    errorMessage,
+    sourcePaths(fileTree),
+  );
+
+  return Promise.reject(new Error(errorMessage));
+};

--- a/src/installer.redscript.ts
+++ b/src/installer.redscript.ts
@@ -46,6 +46,7 @@ import {
   VortexTestResult,
   VortexInstallResult,
 } from "./vortex-wrapper";
+import { detectRed4ExtCanonOnlyLayout } from "./installer.red4ext";
 
 const matchRedscriptFile = (file: string): boolean =>
   pathEq(REDS_MOD_CANONICAL_EXTENSION)(path.extname(file));
@@ -69,6 +70,7 @@ export const detectRedscriptCanonOnlyLayout = (fileTree: FileTree): boolean =>
 export const detectRedscriptToplevelLayout = (fileTree: FileTree): boolean =>
   !detectRedscriptBasedirLayout(fileTree)
   && !detectRedscriptCanonOnlyLayout(fileTree)
+  && !detectRed4ExtCanonOnlyLayout(fileTree) // since Red4Ext mods can have embedded reds, we don't want to mistake oe for the other
   && dirWithSomeIn(FILETREE_ROOT, matchRedscriptFile, fileTree);
 
 const detectRedscriptLayout = (fileTree: FileTree): boolean =>

--- a/src/installer.redscript.ts
+++ b/src/installer.redscript.ts
@@ -70,12 +70,11 @@ export const detectRedscriptCanonOnlyLayout = (fileTree: FileTree): boolean =>
 export const detectRedscriptToplevelLayout = (fileTree: FileTree): boolean =>
   !detectRedscriptBasedirLayout(fileTree)
   && !detectRedscriptCanonOnlyLayout(fileTree)
-  && !detectRed4ExtCanonOnlyLayout(fileTree) // since Red4Ext mods can have embedded reds, we don't want to mistake oe for the other
   && dirWithSomeIn(FILETREE_ROOT, matchRedscriptFile, fileTree);
 
 const detectRedscriptLayout = (fileTree: FileTree): boolean =>
-  allRedscriptConfigFiles(fileTree).length > 0
-  || dirWithSomeUnder(FILETREE_ROOT, matchRedscriptFile, fileTree);
+  (allRedscriptConfigFiles(fileTree).length > 0 || dirWithSomeUnder(FILETREE_ROOT, matchRedscriptFile, fileTree))
+  && !detectRed4ExtCanonOnlyLayout(fileTree); // since Red4Ext mods can have embedded reds, we don't want to mistake oe for the other
 
 
 //

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -177,6 +177,31 @@ export const DEPRECATED_INPUT_LOADER_CORE_FILES = {
 };
 export const DEPRECATED_INPUT_LOADER_CORE_REQUIRED_FILES = DEPRECATED_INPUT_LOADER_CORE_FILES;
 
+//
+// Core Mod Settings
+
+export const enum CoreModSettingsLayout {
+  OnlyValid = `
+              - .\\red4ext\\plugins\\mod_settings\\ModSettings.archive
+              - .\\red4ext\\plugins\\mod_settings\\ModSettings.archive.xl
+              - .\\red4ext\\plugins\\mod_settings\\mod_settings.dll
+              - .\\red4ext\\plugins\\mod_settings\\module.reds
+              - .\\red4ext\\plugins\\mod_settings\\packed.reds
+              - .\\red4ext\\plugins\\mod_settings\\license.md
+              - .\\red4ext\\plugins\\mod_settings\\readme.md
+              `,
+}
+
+export const MOD_SETTINGS_CORE_FILES = [
+  path.join(`red4ext\\plugins\\mod_settings\\ModSettings.archive`),
+  path.join(`red4ext\\plugins\\mod_settings\\ModSettings.archive.xl`),
+  path.join(`red4ext\\plugins\\mod_settings\\mod_settings.dll`),
+  path.join(`red4ext\\plugins\\mod_settings\\module.reds`),
+  path.join(`red4ext\\plugins\\mod_settings\\packed.reds`),
+  path.join(`red4ext\\plugins\\mod_settings\\license.md`),
+  path.join(`red4ext\\plugins\\mod_settings\\readme.md`),
+];
+
 
 //
 // Core TweakXL
@@ -639,7 +664,7 @@ export const REDS_MOD_CANONICAL_HINTS_PATH_PREFIX = path.normalize(`r6/config/re
 
 export const enum Red4ExtLayout {
   Canon = `.\\red4ext\\plugins\\[modname]\\[*.dll, any files or subdirs]`,
-  Basedir = `.\\red4ext\\plugins\\[*.dll, any files or subdirs]`,
+  Basedir = `.\\red4ext\\plugins\\[*.dll, any files or subdirs]`, // @TODO: No longer supported by Red4ext core
   Modnamed = `.\\[modname]\\[*.dll, any files or subdirs]`,
   Toplevel = `.\\[*.dll, any files or subdirs]`,
 }
@@ -896,6 +921,14 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
         This older version can still be installed, but should be updated:
 
         \`${CoreInputLoaderLayout.PreviousV010}\`
+    `,
+  ],
+  [
+    InstallerType.CoreModSettings,
+    `
+    \`${CoreModSettingsLayout.OnlyValid}\`
+
+    This is the only possible valid layout for ${InstallerType.CoreModSettings} that I know of.
     `,
   ],
   [

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -1,11 +1,17 @@
-import { win32 } from "path";
-import { pipe } from "fp-ts/lib/function";
+import {
+  win32,
+} from "path";
+import {
+  pipe,
+} from "fp-ts/lib/function";
 import {
   filter,
   map,
   toArray,
 } from "fp-ts/lib/ReadonlyArray";
-import { not } from "fp-ts/lib/Predicate";
+import {
+  not,
+} from "fp-ts/lib/Predicate";
 import {
   fileCount,
   FileTree,
@@ -36,7 +42,9 @@ import {
   testForCetCore,
   installCetCore,
 } from "./installer.core";
-import { GAME_ID } from "./index.metadata";
+import {
+  GAME_ID,
+} from "./index.metadata";
 import {
   Installer,
   InstallerType,
@@ -97,8 +105,12 @@ import {
   testForRedscriptMod,
   installRedscriptMod,
 } from "./installer.redscript";
-import { modInfoFromArchiveNameOrSynthetic } from "./installers.shared";
-import { extraFilesAllowedInOtherModTypesInstructions } from "./installer.special.extrafiles";
+import {
+  modInfoFromArchiveNameOrSynthetic,
+} from "./installers.shared";
+import {
+  extraFilesAllowedInOtherModTypesInstructions,
+} from "./installer.special.extrafiles";
 import {
   InfoNotification,
   showInfoNotification,
@@ -143,7 +155,13 @@ import {
   installCoreRedscript,
   testForCoreRedscript,
 } from "./installer.core.redscript";
-import { FeatureSet } from "./features";
+import {
+  FeatureSet,
+} from "./features";
+import {
+  installCoreModSettings,
+  testForCoreModSettings,
+} from "./installer.core.modsettings";
 
 // Ensure we're using win32 conventions
 const path = win32;

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -244,6 +244,12 @@ const installers: Installer[] = [
     install: installCoreInputLoader,
   },
   {
+    type: InstallerType.CoreModSettings,
+    id: InstallerType.CoreModSettings,
+    testSupported: testForCoreModSettings,
+    install: installCoreModSettings,
+  },
+  {
     type: InstallerType.CoreCyberCat,
     id: InstallerType.CoreCyberCat,
     testSupported: testForCyberCatCore,

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -42,6 +42,7 @@ export enum InstallerType {
   CoreRedscript = `Core Redscript Installer`,
   CoreRed4ext = `Core RED4ext Installer`,
   CoreInputLoader = `Core Input Loader Installer (special case of Red4Ext)`,
+  CoreModSettings = `Core Mod Settings Installer (special case of Red4Ext)`,
   CoreCSVMerge = `(DEPRECATED - use TweakXL/ArchiveXL) Core CSVMerge Installer`,
   CoreCyberCat = `CyberCAT Save Editor Installer`,
   CoreTweakXL = `Core TweakXL Installer`,

--- a/test/unit/mods.example.core.modsettings.ts
+++ b/test/unit/mods.example.core.modsettings.ts
@@ -1,0 +1,62 @@
+import path from "path";
+import {
+  map,
+} from "fp-ts/lib/ReadonlyArray";
+import {
+  pipe,
+} from "fp-ts/lib/function";
+import {
+  InstallerType,
+} from "../../src/installers.types";
+import {
+  copiedToSamePath,
+  ExampleFailingMod,
+  ExamplePromptInstallableMod,
+  ExamplesForType,
+  ExampleSucceedingMod,
+  RED4EXT_PREFIXES,
+  RED4EXT_PREFIX,
+} from "./utils.helper";
+
+
+const CoreInputLoaderInstallSucceeds = new Map<string, ExampleSucceedingMod>(
+  Object.entries({
+    red4extWithRedScriptEmbeddedCanonical: {
+      expectedInstallerType: InstallerType.CoreModSettings,
+      inFiles: [
+        ...RED4EXT_PREFIXES,
+        path.join(`${RED4EXT_PREFIX}/mod_settings/`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/ModSettings.archive`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/ModSettings.archive.xl`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/license.md`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/mod_settings.dll`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/module.reds`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/packed.reds`),
+        path.join(`${RED4EXT_PREFIX}/mod_settings/readme.md`),
+      ],
+      outInstructions: [
+        ...pipe(
+          [
+            path.join(`${RED4EXT_PREFIX}/mod_settings/ModSettings.archive`),
+            path.join(`${RED4EXT_PREFIX}/mod_settings/ModSettings.archive.xl`),
+            path.join(`${RED4EXT_PREFIX}/mod_settings/license.md`),
+            path.join(`${RED4EXT_PREFIX}/mod_settings/mod_settings.dll`),
+            path.join(`${RED4EXT_PREFIX}/mod_settings/module.reds`),
+            path.join(`${RED4EXT_PREFIX}/mod_settings/packed.reds`),
+            path.join(`${RED4EXT_PREFIX}/mod_settings/readme.md`),
+          ],
+          map(copiedToSamePath),
+        ),
+      ],
+    },
+  }),
+);
+
+
+const examples: ExamplesForType = {
+  AllExpectedSuccesses: CoreInputLoaderInstallSucceeds,
+  AllExpectedDirectFailures: new Map<string, ExampleFailingMod>(),
+  AllExpectedPromptInstalls: new Map<string, ExamplePromptInstallableMod>(),
+};
+
+export default examples;

--- a/test/unit/mods.example.red4ext.ts
+++ b/test/unit/mods.example.red4ext.ts
@@ -1,10 +1,20 @@
 import path from "path";
 import {
+  pipe,
+} from "fp-ts/lib/function";
+import {
+  map,
+} from "fp-ts/lib/ReadonlyArray";
+import {
   RED4EXT_KNOWN_NONOVERRIDABLE_DLL_DIRS,
   RED4EXT_KNOWN_NONOVERRIDABLE_DLLS,
 } from "../../src/installers.layouts";
-import { InstallerType } from "../../src/installers.types";
-import { InstallChoices } from "../../src/ui.dialogs";
+import {
+  InstallerType,
+} from "../../src/installers.types";
+import {
+  InstallChoices,
+} from "../../src/ui.dialogs";
 import {
   ExampleSucceedingMod,
   RED4EXT_PREFIXES,
@@ -15,6 +25,7 @@ import {
   expectedUserCancelMessageFor,
   expectedUserCancelMessageForHittingFallback,
   ExamplesForType,
+  copiedToSamePath,
 } from "./utils.helper";
 
 const Red4ExtModSucceeds = new Map<string, ExampleSucceedingMod>(
@@ -53,6 +64,26 @@ const Red4ExtModSucceeds = new Map<string, ExampleSucceedingMod>(
           source: path.join(`${RED4EXT_PREFIX}/r4emod/notascript.dll`),
           destination: path.join(`${RED4EXT_PREFIX}/r4emod/notascript.dll`),
         },
+      ],
+    },
+    red4extWithRedScriptEmbeddedCanonical: {
+      expectedInstallerType: InstallerType.Red4Ext,
+      inFiles: [
+        ...RED4EXT_PREFIXES,
+        path.join(`${RED4EXT_PREFIX}/r4emod/`),
+        path.join(`${RED4EXT_PREFIX}/r4emod/script.dll`),
+        path.join(`${RED4EXT_PREFIX}/r4emod/module.reds`),
+        path.join(`${RED4EXT_PREFIX}/r4emod/readme.md`),
+      ],
+      outInstructions: [
+        ...pipe(
+          [
+            path.join(`${RED4EXT_PREFIX}/r4emod/script.dll`),
+            path.join(`${RED4EXT_PREFIX}/r4emod/module.reds`),
+            path.join(`${RED4EXT_PREFIX}/r4emod/readme.md`),
+          ],
+          map(copiedToSamePath),
+        ),
       ],
     },
     red4extIncludingNonRedsAndNonemptySubdirsCanonical: {


### PR DESCRIPTION
Adds mod settings as a specific installer. Does not detect the redscript installer if it has a red4ext path.

Fixes #373 