### PR TITLE
feat: allow users to see redmod deploy logs by adding pause

### DIFF
--- a/src/load_order.ts
+++ b/src/load_order.ts
@@ -485,7 +485,12 @@ export const redmodDeployRunParameters = (
   gameDirPath: string,
 ): VortexRunParameters => {
 
+  const exePath =
+    path.join(gameDirPath, REDdeployExeRelativePath);
+
   const redModDeployParametersToCreateNewManifest = [
+    '/k',
+    exePath,
     `deploy`,
     `-force`, // TODO: Required until https://github.com/E1337Kat/cyberpunk2077_ext_redux/issues/297
     `-root=`,
@@ -496,8 +501,7 @@ export const redmodDeployRunParameters = (
     `"${path.join(gameDirPath, V2077_MODLIST_PATH)}"`,
   ];
 
-  const exePath =
-    path.join(gameDirPath, REDdeployExeRelativePath);
+  const wrapperExe = "cmd.exe"
 
   const runOptions: VortexRunOptions = {
     cwd: path.dirname(exePath),
@@ -507,7 +511,7 @@ export const redmodDeployRunParameters = (
   };
 
   return {
-    executable: exePath,
+    executable: wrapperExe,
     args: redModDeployParametersToCreateNewManifest,
     options: runOptions,
   };

--- a/src/tools.redmodding.ts
+++ b/src/tools.redmodding.ts
@@ -100,7 +100,7 @@ export const REDdeployManual: VortexToolShim = {
   relative: true,
   requiredFiles: [REDdeployExeRelativePath],
   executable: constant(REDdeployExeRelativePath),
-  parameters: [REDdeployManualToolNeedsLOGenerated, ' & pause'],
+  parameters: [REDdeployManualToolNeedsLOGenerated],
   shell: true,
   exclusive: true,
   // Can't be set here for some reason, we do this in the hook instead


### PR DESCRIPTION
Hello!

When we use this extension and deploy RedMods, a command prompt pops up to see the deployment logs for redmod.exe. This is great when the build is not cached and you can actually tail the logs. However, when the RedMod deployment fails, and the deploy is cached, then the command prompt logs disappears almost immediately! This makes it hard to debug, so I'm suggesting to have the command prompt not automatically exit. This is a draft pull request based on: https://stackoverflow.com/a/60053224, I have not tested this functionality and need some guidance on how to refine this. Ideally, we only want this if the deploy fails!