### PR TITLE
✨ [#376] Add support for Input Loader 0.1.2

### DIFF
--- a/src/installer.core.inputloader.ts
+++ b/src/installer.core.inputloader.ts
@@ -121,15 +121,19 @@ const findCoreInputLoaderFiles = (fileTree: FileTree): string[] => [
   ...INPUT_LOADER_CORE_REQUIRED_FILES.V012.filter((requiredFile) => pathInTree(requiredFile, fileTree)),
 ];
 
-const findDeprecatedCoreInputLoaderFiles = (fileTree: FileTree): string[] => [
+const findDeprecated010CoreInputLoaderFiles = (fileTree: FileTree): string[] => [
   ...DEPRECATED_INPUT_LOADER_CORE_FILES.V010.filter((deprecatedFile) => pathInTree(deprecatedFile, fileTree)),
+];
+
+const findDeprecated011CoreInputLoaderFiles = (fileTree: FileTree): string[] => [
   ...DEPRECATED_INPUT_LOADER_CORE_FILES.V011.filter((deprecatedFile) => pathInTree(deprecatedFile, fileTree)),
 ];
 
 const detectCoreInputLoader = (fileTree: FileTree): boolean =>
   // We just need to know this looks like it should be a core input loader installation, for errors
   findCoreInputLoaderFiles(fileTree).length > 0
-  || findDeprecatedCoreInputLoaderFiles(fileTree).length > 0;
+  || findDeprecated010CoreInputLoaderFiles(fileTree).length > 0
+  || findDeprecated011CoreInputLoaderFiles(fileTree).length > 0;
 
 
 // test
@@ -145,21 +149,23 @@ export const testForCoreInputLoader: V2077TestFunc = (
 
 
 const shouldHandleDeprecated010Installation = (
-  deprecatedInstallationFiles: string[],
   fileTree: FileTree,
-): boolean => (deprecatedInstallationFiles.length === fileCount(fileTree)
+): boolean => {
+  const deprecatedInstallationFiles = findDeprecated010CoreInputLoaderFiles(fileTree);
+  return (deprecatedInstallationFiles.length === fileCount(fileTree)
       && deprecatedInstallationFiles.length === DEPRECATED_INPUT_LOADER_CORE_FILES.V010.length);
+};
 
 const shouldHandleDeprecated011Installation = (
-  deprecatedInstallationFiles: string[],
   fileTree: FileTree,
-): boolean => (deprecatedInstallationFiles.length === fileCount(fileTree)
+): boolean => {
+  const deprecatedInstallationFiles = findDeprecated011CoreInputLoaderFiles(fileTree);
+  return (deprecatedInstallationFiles.length === fileCount(fileTree)
       && deprecatedInstallationFiles.length === DEPRECATED_INPUT_LOADER_CORE_FILES.V011.length);
+};
 
 const handleDeprecated010Installation = async (
   api: VortexApi,
-  _deprecatedInstallationFiles: string[],
-  _fileTree: FileTree,
 ): Promise<VortexInstallResult | never> => {
   const infoMessage = `Old core mod version!`;
   api.log(`info`, `${me}: ${infoMessage} Confirming installation.`);
@@ -183,8 +189,6 @@ const handleDeprecated010Installation = async (
 
 const handleDeprecated011Installation = async (
   api: VortexApi,
-  _deprecatedInstallationFiles: string[],
-  _fileTree: FileTree,
 ): Promise<VortexInstallResult | never> => {
   const infoMessage = `Old core mod version!`;
   api.log(`info`, `${me}: ${infoMessage} Confirming installation.`);
@@ -219,13 +223,12 @@ export const installCoreInputLoader: V2077InstallFunc = async (
     return Promise.resolve({ instructions: CoreInputLoaderInstructions });
   }
 
-  const deprecatedInstallationFiles = findDeprecatedCoreInputLoaderFiles(fileTree);
-
-  if (shouldHandleDeprecated010Installation(deprecatedInstallationFiles, fileTree)) {
-    return handleDeprecated010Installation(api, deprecatedInstallationFiles, fileTree);
+  if (shouldHandleDeprecated010Installation(fileTree)) {
+    return handleDeprecated010Installation(api);
   }
-  if (shouldHandleDeprecated011Installation(deprecatedInstallationFiles, fileTree)) {
-    return handleDeprecated011Installation(api, deprecatedInstallationFiles, fileTree);
+
+  if (shouldHandleDeprecated011Installation(fileTree)) {
+    return handleDeprecated011Installation(api);
   }
 
   const errorMessage = `Didn't Find Expected Input Loader Installation!`;

--- a/src/installer.core.inputloader.ts
+++ b/src/installer.core.inputloader.ts
@@ -2,6 +2,7 @@ import {
   VortexApi,
   VortexTestResult,
   VortexInstruction,
+  VortexInstallResult,
 } from "./vortex-wrapper";
 import {
   FileTree,
@@ -31,7 +32,7 @@ import {
 
 const me = InstallerType.CoreInputLoader;
 
-const DeprecatedCoreInputLoaderInstructions: VortexInstruction[] = [
+const DeprecatedCoreInputLoader010Instructions: VortexInstruction[] = [
   {
     type: `generatefile`,
     data: `[Player/Input]\n`,
@@ -53,7 +54,8 @@ const DeprecatedCoreInputLoaderInstructions: VortexInstruction[] = [
   },
 ];
 
-const CoreInputLoaderInstructions: VortexInstruction[] = [
+
+const DeprecatedCoreInputLoader011Instructions: VortexInstruction[] = [
   {
     type: `copy`,
     source: `red4ext\\plugins\\input_loader\\license.md`,
@@ -69,16 +71,59 @@ const CoreInputLoaderInstructions: VortexInstruction[] = [
     source: `red4ext\\plugins\\input_loader_uninstall.bat`,
     destination: `red4ext\\plugins\\input_loader_uninstall.bat`,
   },
-  ...DeprecatedCoreInputLoaderInstructions,
+  ...DeprecatedCoreInputLoader010Instructions,
+];
+
+const CoreInputLoaderInstructions: VortexInstruction[] = [
+  {
+    type: `copy`,
+    source: `engine\\config\\platform\\pc\\input_loader.ini`,
+    destination: `engine\\config\\platform\\pc\\input_loader.ini`,
+  },
+  {
+    type: `mkdir`,
+    destination: CONFIG_XML_MOD_MERGEABLE_BASEDIR,
+  },
+  {
+    type: `copy`,
+    source: `r6\\cache\\inputUserMappings.xml`,
+    destination: `r6\\cache\\inputUserMappings.xml`,
+  },
+  {
+    type: `copy`,
+    source: `r6\\cache\\inputContexts.xml`,
+    destination: `r6\\cache\\inputContexts.xml`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\input_loader\\input_loader.dll`,
+    destination: `red4ext\\plugins\\input_loader\\input_loader.dll`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\input_loader\\inputUserMappings.xml`,
+    destination: `red4ext\\plugins\\input_loader\\inputUserMappings.xml`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\input_loader\\license.md`,
+    destination: `red4ext\\plugins\\input_loader\\license.md`,
+  },
+  {
+    type: `copy`,
+    source: `red4ext\\plugins\\input_loader\\readme.md`,
+    destination: `red4ext\\plugins\\input_loader\\readme.md`,
+  },
 ];
 
 
 const findCoreInputLoaderFiles = (fileTree: FileTree): string[] => [
-  ...INPUT_LOADER_CORE_REQUIRED_FILES.V011.filter((requiredFile) => pathInTree(requiredFile, fileTree)),
+  ...INPUT_LOADER_CORE_REQUIRED_FILES.V012.filter((requiredFile) => pathInTree(requiredFile, fileTree)),
 ];
 
 const findDeprecatedCoreInputLoaderFiles = (fileTree: FileTree): string[] => [
   ...DEPRECATED_INPUT_LOADER_CORE_FILES.V010.filter((deprecatedFile) => pathInTree(deprecatedFile, fileTree)),
+  ...DEPRECATED_INPUT_LOADER_CORE_FILES.V011.filter((deprecatedFile) => pathInTree(deprecatedFile, fileTree)),
 ];
 
 const detectCoreInputLoader = (fileTree: FileTree): boolean =>
@@ -99,6 +144,68 @@ export const testForCoreInputLoader: V2077TestFunc = (
 // install
 
 
+const shouldHandleDeprecated010Installation = (
+  deprecatedInstallationFiles: string[],
+  fileTree: FileTree,
+): boolean => (deprecatedInstallationFiles.length === fileCount(fileTree)
+      && deprecatedInstallationFiles.length === DEPRECATED_INPUT_LOADER_CORE_FILES.V010.length);
+
+const shouldHandleDeprecated011Installation = (
+  deprecatedInstallationFiles: string[],
+  fileTree: FileTree,
+): boolean => (deprecatedInstallationFiles.length === fileCount(fileTree)
+      && deprecatedInstallationFiles.length === DEPRECATED_INPUT_LOADER_CORE_FILES.V011.length);
+
+const handleDeprecated010Installation = async (
+  api: VortexApi,
+  _deprecatedInstallationFiles: string[],
+  _fileTree: FileTree,
+): Promise<VortexInstallResult | never> => {
+  const infoMessage = `Old core mod version!`;
+  api.log(`info`, `${me}: ${infoMessage} Confirming installation.`);
+
+  const confirmedInstructions = await promptUserToInstallOrCancelOnDeprecatedCoreMod(
+    api,
+    InstallerType.CoreInputLoader,
+    [] as string[],
+  );
+
+  if (confirmedInstructions === InstallDecision.UserWantsToCancel) {
+    const cancelMessage = `${me}: user chose to cancel installing deprecated version`;
+
+    api.log(`warn`, cancelMessage);
+    return Promise.reject(new Error(cancelMessage));
+  }
+
+  api.log(`info`, `${me}: User confirmed installing deprecated version`);
+  return Promise.resolve({ instructions: DeprecatedCoreInputLoader010Instructions });
+};
+
+const handleDeprecated011Installation = async (
+  api: VortexApi,
+  _deprecatedInstallationFiles: string[],
+  _fileTree: FileTree,
+): Promise<VortexInstallResult | never> => {
+  const infoMessage = `Old core mod version!`;
+  api.log(`info`, `${me}: ${infoMessage} Confirming installation.`);
+
+  const confirmedInstructions = await promptUserToInstallOrCancelOnDeprecatedCoreMod(
+    api,
+    InstallerType.CoreInputLoader,
+    [] as string[],
+  );
+
+  if (confirmedInstructions === InstallDecision.UserWantsToCancel) {
+    const cancelMessage = `${me}: user chose to cancel installing deprecated version`;
+
+    api.log(`warn`, cancelMessage);
+    return Promise.reject(new Error(cancelMessage));
+  }
+
+  api.log(`info`, `${me}: User confirmed installing deprecated version`);
+  return Promise.resolve({ instructions: DeprecatedCoreInputLoader011Instructions });
+};
+
 export const installCoreInputLoader: V2077InstallFunc = async (
   api: VortexApi,
   fileTree: FileTree,
@@ -108,32 +215,17 @@ export const installCoreInputLoader: V2077InstallFunc = async (
   const currentInstallationFiles = findCoreInputLoaderFiles(fileTree);
 
   if (currentInstallationFiles.length === fileCount(fileTree)
-    && currentInstallationFiles.length === INPUT_LOADER_CORE_REQUIRED_FILES.V011.length) {
+    && currentInstallationFiles.length === INPUT_LOADER_CORE_REQUIRED_FILES.V012.length) {
     return Promise.resolve({ instructions: CoreInputLoaderInstructions });
   }
 
   const deprecatedInstallationFiles = findDeprecatedCoreInputLoaderFiles(fileTree);
 
-  if (deprecatedInstallationFiles.length === fileCount(fileTree)
-      && deprecatedInstallationFiles.length === DEPRECATED_INPUT_LOADER_CORE_FILES.V010.length) {
-    const infoMessage = `Old core mod version!`;
-    api.log(`info`, `${me}: ${infoMessage} Confirming installation.`);
-
-    const confirmedInstructions = await promptUserToInstallOrCancelOnDeprecatedCoreMod(
-      api,
-      InstallerType.CoreInputLoader,
-      [] as string[],
-    );
-
-    if (confirmedInstructions === InstallDecision.UserWantsToCancel) {
-      const cancelMessage = `${me}: user chose to cancel installing deprecated version`;
-
-      api.log(`warn`, cancelMessage);
-      return Promise.reject(new Error(cancelMessage));
-    }
-
-    api.log(`info`, `${me}: User confirmed installing deprecated version`);
-    return Promise.resolve({ instructions: DeprecatedCoreInputLoaderInstructions });
+  if (shouldHandleDeprecated010Installation(deprecatedInstallationFiles, fileTree)) {
+    return handleDeprecated010Installation(api, deprecatedInstallationFiles, fileTree);
+  }
+  if (shouldHandleDeprecated011Installation(deprecatedInstallationFiles, fileTree)) {
+    return handleDeprecated011Installation(api, deprecatedInstallationFiles, fileTree);
   }
 
   const errorMessage = `Didn't Find Expected Input Loader Installation!`;

--- a/src/installers.layouts.ts
+++ b/src/installers.layouts.ts
@@ -141,7 +141,16 @@ export const DEPRECATED_REDSCRIPT_CORE_REQUIRED_FILES = DEPRECATED_REDSCRIPT_COR
 // Core Input_Loader
 
 export const enum CoreInputLoaderLayout {
-  CurrentV011 = `
+  CurrentV012 = `
+              - .\\engine\\config\\platform\\pc\\input_loader.ini
+              - .\\r6\\cache\\inputContexts.xml
+              - .\\r6\\cache\\inputUserMappings.xml
+              - .\\red4ext\\plugins\\input_loader\\input_loader.dll
+              - .\\red4ext\\plugins\\input_loader\\inputUserMappings.xml
+              - .\\red4ext\\plugins\\input_loader\\license.md
+              - .\\red4ext\\plugins\\input_loader\\readme.md
+              `,
+  PreviousV011 = `
               - .\\engine\\config\\platform\\pc\\input_loader.ini
               - .\\r6\\input\\                       (note, empty directory is an exception)
               - .\\red4ext\\plugins\\input_loader\\input_loader.dll
@@ -158,7 +167,22 @@ export const enum CoreInputLoaderLayout {
               `,
 }
 
+export const CYBERPUNK_CACHE_PATH = path.join(`r6\\cache`);
+
 export const INPUT_LOADER_CORE_FILES = {
+  V012: [
+    path.join(`engine\\config\\platform\\pc\\input_loader.ini`),
+    path.join(`r6\\cache\\inputContexts.xml`),
+    path.join(`r6\\cache\\inputUserMappings.xml`),
+    path.join(`red4ext\\plugins\\input_loader\\input_loader.dll`),
+    path.join(`red4ext\\plugins\\input_loader\\inputUserMappings.xml`),
+    path.join(`red4ext\\plugins\\input_loader\\license.md`),
+    path.join(`red4ext\\plugins\\input_loader\\readme.md`),
+  ],
+};
+export const INPUT_LOADER_CORE_REQUIRED_FILES = INPUT_LOADER_CORE_FILES;
+
+export const DEPRECATED_INPUT_LOADER_CORE_FILES = {
   V011: [
     path.join(`red4ext\\plugins\\input_loader\\input_loader.dll`),
     path.join(`red4ext\\plugins\\input_loader\\inputUserMappings.xml`),
@@ -166,10 +190,6 @@ export const INPUT_LOADER_CORE_FILES = {
     path.join(`red4ext\\plugins\\input_loader\\readme.md`),
     path.join(`red4ext\\plugins\\input_loader_uninstall.bat`),
   ],
-};
-export const INPUT_LOADER_CORE_REQUIRED_FILES = INPUT_LOADER_CORE_FILES;
-
-export const DEPRECATED_INPUT_LOADER_CORE_FILES = {
   V010: [
     path.join(`red4ext\\plugins\\input_loader\\input_loader.dll`),
     path.join(`red4ext\\plugins\\input_loader\\inputUserMappings.xml`),
@@ -915,11 +935,13 @@ export const LayoutDescriptions = new Map<InstallerType, string>([
   [
     InstallerType.CoreInputLoader,
     `
-        \`${CoreInputLoaderLayout.CurrentV011}\`
+        \`${CoreInputLoaderLayout.CurrentV012}\`
 
         This is the only possible valid layout for ${InstallerType.CoreInputLoader} that I know of.
-        This older version can still be installed, but should be updated:
+        These older versions can still be installed, but should be updated:
 
+        \`${CoreInputLoaderLayout.PreviousV011}\`
+        AND
         \`${CoreInputLoaderLayout.PreviousV010}\`
     `,
   ],

--- a/src/installers.types.ts
+++ b/src/installers.types.ts
@@ -17,7 +17,9 @@ import {
   fromNullable,
   getOrElse as getOrElseO,
 } from "fp-ts/lib/Option";
-import { FeatureSet } from "./features";
+import {
+  FeatureSet,
+} from "./features";
 import {
   FileTree,
   Path,
@@ -28,7 +30,9 @@ import {
   VortexInstallResult,
   VortexMod,
 } from "./vortex-wrapper";
-import { S } from "./util.functions";
+import {
+  S,
+} from "./util.functions";
 
 export enum InstallerType {
   // Meta-installer, won't be in the pipeline itself

--- a/test/unit/mods.example.core.inputloader.ts
+++ b/test/unit/mods.example.core.inputloader.ts
@@ -8,6 +8,7 @@ import {
 import {
   CONFIG_INI_MOD_BASEDIR,
   CONFIG_XML_MOD_MERGEABLE_BASEDIR,
+  CYBERPUNK_CACHE_PATH,
 } from "../../src/installers.layouts";
 import {
   InstallerType,
@@ -28,6 +29,15 @@ import {
 } from "../../src/ui.dialogs";
 
 const inputLoaderInFiles = {
+  v012: [
+    path.join(`${RED4EXT_PREFIX}\\input_loader\\input_loader.dll`),
+    path.join(`${RED4EXT_PREFIX}\\input_loader\\inputUserMappings.xml`),
+    path.join(`${RED4EXT_PREFIX}\\input_loader\\license.md`),
+    path.join(`${RED4EXT_PREFIX}\\input_loader\\readme.md`),
+    path.join(`${CONFIG_INI_MOD_BASEDIR}\\input_loader.ini`),
+    path.join(`${CYBERPUNK_CACHE_PATH}\\inputContexts.xml`),
+    path.join(`${CYBERPUNK_CACHE_PATH}\\inputUserMappings.xml`),
+  ],
   v011: [
     path.join(`${RED4EXT_PREFIX}\\input_loader\\input_loader.dll`),
     path.join(`${RED4EXT_PREFIX}\\input_loader\\inputUserMappings.xml`),
@@ -44,18 +54,18 @@ const inputLoaderInFiles = {
 
 const CoreInputLoaderInstallSucceeds = new Map<string, ExampleSucceedingMod>([
   [
-    `Core Input Loader version v0.1.1 installs without prompting when all required paths present`,
+    `Core Input Loader version v0.1.2 installs without prompting when all required paths present`,
     {
       expectedInstallerType: InstallerType.CoreInputLoader,
       inFiles: [
         ...pathHierarchyFor(`${RED4EXT_PREFIX}\\input_loader\\`),
-        ...inputLoaderInFiles.v011,
+        ...inputLoaderInFiles.v012,
       ],
       outInstructions: [
         generatedFile(`[Player/Input]\n`, `${CONFIG_INI_MOD_BASEDIR}\\input_loader.ini`),
         createdDirectory(`${CONFIG_XML_MOD_MERGEABLE_BASEDIR}`), // This is a special case
         ...pipe(
-          inputLoaderInFiles.v011,
+          inputLoaderInFiles.v012,
           map(copiedToSamePath),
         ),
       ],
@@ -65,6 +75,27 @@ const CoreInputLoaderInstallSucceeds = new Map<string, ExampleSucceedingMod>([
 
 
 const CoreInputLoaderDeprecatedPromptsToInstall = new Map<string, ExamplePromptInstallableMod>([
+  [
+    `Deprecated Core Input Loader version v0.1.1 installs when all required paths present`,
+    {
+      expectedInstallerType: InstallerType.CoreInputLoader,
+      inFiles: [
+        ...pathHierarchyFor(`${RED4EXT_PREFIX}\\input_loader\\`),
+        ...inputLoaderInFiles.v011,
+      ],
+      proceedLabel: InstallChoices.Proceed,
+      proceedOutInstructions: [
+        generatedFile(`[Player/Input]\n`, `${CONFIG_INI_MOD_BASEDIR}\\input_loader.ini`),
+        createdDirectory(`${CONFIG_XML_MOD_MERGEABLE_BASEDIR}`), // This is a special case
+        ...pipe(
+          inputLoaderInFiles.v011,
+          map(copiedToSamePath),
+        ),
+      ],
+      cancelLabel: InstallChoices.Cancel,
+      cancelErrorMessage: `${InstallerType.CoreInputLoader}: user chose to cancel installing deprecated version`,
+    },
+  ],
   [
     `Deprecated Core Input Loader version v0.1.0 installs when all required paths present`,
     {

--- a/test/unit/mods.example.core.inputloader.ts
+++ b/test/unit/mods.example.core.inputloader.ts
@@ -59,10 +59,11 @@ const CoreInputLoaderInstallSucceeds = new Map<string, ExampleSucceedingMod>([
       expectedInstallerType: InstallerType.CoreInputLoader,
       inFiles: [
         ...pathHierarchyFor(`${RED4EXT_PREFIX}\\input_loader\\`),
+        ...pathHierarchyFor(`${CONFIG_INI_MOD_BASEDIR}\\`),
+        ...pathHierarchyFor(`${CYBERPUNK_CACHE_PATH}\\`),
         ...inputLoaderInFiles.v012,
       ],
       outInstructions: [
-        generatedFile(`[Player/Input]\n`, `${CONFIG_INI_MOD_BASEDIR}\\input_loader.ini`),
         createdDirectory(`${CONFIG_XML_MOD_MERGEABLE_BASEDIR}`), // This is a special case
         ...pipe(
           inputLoaderInFiles.v012,


### PR DESCRIPTION
🗑️ Deprecate Input Loader 1.1.1
🎨 Also fix formatting in installers.types.ts and installers.layouts.ts

This adds support for input Loader 0.1.2 and up to at least the current 0.2.2. I got GitHub Copilot through my workplace and that helped knock this out pretty  quickly after some finagling. I also reduced some complexity in the installer function because VSCode said it was toooooo much. Also added tests and did some light formatting.

Closes #376 